### PR TITLE
Convert weighted minhash's state to float32

### DIFF
--- a/datasketch/weighted_minhash.py
+++ b/datasketch/weighted_minhash.py
@@ -72,9 +72,9 @@ class WeightedMinHashGenerator(object):
         self.sample_size = sample_size
         self.seed = seed
         generator = np.random.RandomState(seed=seed)
-        self.rs = generator.gamma(2, 1, (sample_size, dim))
-        self.ln_cs = np.log(generator.gamma(2, 1, (sample_size, dim)))
-        self.betas = generator.uniform(0, 1, (sample_size, dim))
+        self.rs = generator.gamma(2, 1, (sample_size, dim)).astype(np.float32)
+        self.ln_cs = np.log(generator.gamma(2, 1, (sample_size, dim))).astype(np.float32)
+        self.betas = generator.uniform(0, 1, (sample_size, dim)).astype(np.float32)
 
     def minhash(self, v):
         '''


### PR DESCRIPTION
By default, random generator produces doubles and that is not affordable with millions of dimensions.
