### PR TITLE
Dramatically speedup and fix LSH's _H()

### DIFF
--- a/datasketch/lsh.py
+++ b/datasketch/lsh.py
@@ -97,7 +97,7 @@ class MinHashLSH(object):
         return any(len(t) == 0 for t in self.hashtables)
 
     def _H(self, hs):
-        return "".join("%.8x" % h for h in hs)
+        return bytes(hs.byteswap().data)
 
     def __contains__(self, key):
         '''
@@ -173,7 +173,3 @@ class WeightedMinHashLSH(MinHashLSH):
         (false_positive_weight, false_negative_weight).
         '''
         super(WeightedMinHashLSH, self).__init__(threshold, sample_size, weights)
-
-    def _H(self, hs):
-        return "".join("%.4x-%.4x" % (k, t) for (k, t) in hs)
-


### PR DESCRIPTION
The same byte result but much faster and actually always the same length.

The old approach is wrong: e.g. len("%.4x"% 741282) is 5, not 4.