### PR TITLE
Test MinHash against fixed result vector

### DIFF
--- a/benchmark/minhash_benchmark.py
+++ b/benchmark/minhash_benchmark.py
@@ -1,7 +1,8 @@
 '''
 Benchmarking the performance and accuracy of MinHash.
 '''
-import time, logging, random
+import time, logging
+from numpy import random
 from hashlib import sha1
 import matplotlib
 matplotlib.use('Agg')

--- a/datasketch/minhash.py
+++ b/datasketch/minhash.py
@@ -65,13 +65,12 @@ class MinHash(object):
         if permutations is not None:
             self.permutations = permutations
         else:
-            generator = random.Random()
-            generator.seed(self.seed)
+            generator = np.random.RandomState(self.seed)
             # Create parameters for a random bijective permutation function
             # that maps a 32-bit hash value to another 32-bit hash value.
             # http://en.wikipedia.org/wiki/Universal_hashing
-            self.permutations = np.array([(generator.randint(1, _mersenne_prime),
-                                           generator.randint(0, _mersenne_prime))
+            self.permutations = np.array([(generator.randint(1, _mersenne_prime, dtype=np.uint64),
+                                           generator.randint(0, _mersenne_prime, dtype=np.uint64))
                                           for _ in range(num_perm)], dtype=np.uint64).T
         if len(self) != len(self.permutations[0]):
             raise ValueError("Numbers of hash values and permutations mismatch")

--- a/test/minhash_test.py
+++ b/test/minhash_test.py
@@ -106,6 +106,13 @@ class TestMinHash(unittest.TestCase):
         c = m.count()
         self.assertGreaterEqual(c, 0)
 
+    def test_byte_tokens(self):
+        m = minhash.MinHash(4, 1)
+        m.update(b'Hello')
+        self.assertListEqual(
+            m.hashvalues.tolist(),
+            [4159347281, 889859675, 2216179651, 3113718761],
+        )
 
 class TestbBitMinHash(unittest.TestCase):
 

--- a/test/minhash_test.py
+++ b/test/minhash_test.py
@@ -111,7 +111,7 @@ class TestMinHash(unittest.TestCase):
         m.update(b'Hello')
         self.assertListEqual(
             m.hashvalues.tolist(),
-            [4159347281, 889859675, 2216179651, 3113718761],
+            [734825475, 960773806, 359816889, 342714745],
         )
 
 class TestbBitMinHash(unittest.TestCase):


### PR DESCRIPTION
I am not sure if your MinHash implementation is supposed to give the  same results on different versions of Python. It currently does not do so. I added the test vectors for the results I get on python 2.7. Unfortunately Python 3.5 gives different results. See: https://travis-ci.org/ekzhu/datasketch/builds/214433266