### PR TITLE
Redis backend for datasketch LSH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ python:
   - "nightly"
 # command to install dependencies
 install:
-    - "pip install ."
+    - "pip install -e .[test]"
 # command to run tests
 script: nosetests

--- a/datasketch/lsh.py
+++ b/datasketch/lsh.py
@@ -1,6 +1,6 @@
 import pickle
 from datasketch.storage import (
-    ordered_storage, unordered_storage)
+    ordered_storage, unordered_storage, _random_name)
 
 _integration_precision = 0.001
 def _integration(f, a, b):
@@ -111,9 +111,12 @@ class MinHashLSH(object):
             self.prepickle = storage_config['type'] == 'redis'
         else:
             self.prepickle = prepickle
-        self.hashtables = [unordered_storage(storage_config) for _ in range(self.b)]
+        basename = _random_name(11)
+        self.hashtables = [
+            unordered_storage(storage_config, name=basename + b'_bucket_' + bytes([i]))
+            for i in range(self.b)]
         self.hashranges = [(i*self.r, (i+1)*self.r) for i in range(self.b)]
-        self.keys = ordered_storage(storage_config)
+        self.keys = ordered_storage(storage_config, name=basename + b'_keys')
 
     def insert(self, key, minhash):
         '''

--- a/datasketch/lsh.py
+++ b/datasketch/lsh.py
@@ -199,3 +199,30 @@ class MinHashLSH(object):
                 for key in hashtable[H]:
                     candidates.add(key)
         return candidates
+
+    def get_counts(self):
+        '''
+        Returns a list of length ``self.b`` with elements representing the
+        number of keys stored under each bucket for the given permutation.
+        '''
+        counts = [
+            hashtable.itemcounts() for hashtable in self.hashtables]
+        return counts
+
+    def get_subset_counts(self, *keys):
+        '''
+        Returns the bucket allocation counts (see :ref:`get_counts` above)
+        restricted to the list of keys given.
+
+        Args:
+            keys (hashable) : the keys for which to get the bucket allocation
+                counts
+        '''
+        key_set = list(set(keys))
+        hashtables = [unordered_storage({'type': 'dict'}) for _ in
+                      range(self.b)]
+        Hss = self.keys.getmany(*key_set)
+        for key, Hs in zip(key_set, Hss):
+            for H, hashtable in zip(Hs, hashtables):
+                hashtable.insert(H, key)
+        return [hashtable.itemcounts() for hashtable in hashtables]

--- a/datasketch/lsh.py
+++ b/datasketch/lsh.py
@@ -76,6 +76,9 @@ class MinHashLSH(object):
             if this is given.
         storage_config (dict, optional): Type of storage service to use for storing
             hashtables and keys.
+        prepickle (bool, optional): If True, all keys are pickled to bytes before
+            insertion. If None, a default value is chosen based on the
+            `storage_config`.
 
     Note: 
         `weights` must sum to 1.0, and the format is 

--- a/datasketch/storage.py
+++ b/datasketch/storage.py
@@ -199,6 +199,9 @@ class RedisStorage:
 
 class RedisListStorage(OrderedStorage, RedisStorage):
 
+    def __init__(self, config, name=None):
+        RedisStorage.__init__(self, config, name=name)
+
     def keys(self):
         return self._redis.hkeys(self._name)
 
@@ -271,6 +274,9 @@ class RedisListStorage(OrderedStorage, RedisStorage):
 
 
 class RedisSetStorage(UnorderedStorage, RedisListStorage):
+
+    def __init__(self, config, name=None):
+        RedisListStorage.__init__(self, config, name=name)
 
     @staticmethod
     def _get_items(r, k):

--- a/datasketch/storage.py
+++ b/datasketch/storage.py
@@ -7,22 +7,22 @@ from abc import ABCMeta, abstractmethod
 ABC = ABCMeta('ABC', (object,), {}) # compatible with Python 2 *and* 3
 
 
-def ordered_storage(config):
+def ordered_storage(config, name=None):
     '''Return ordered storage system based on the specified config'''
     tp = config['type']
     if tp == 'dict':
         return DictListStorage(config)
     if tp == 'redis':
-        return RedisListStorage(config)
+        return RedisListStorage(config, name=name)
 
 
-def unordered_storage(config):
+def unordered_storage(config, name=None):
     '''Return an unordered storage system based on the specified config'''
     tp = config['type']
     if tp == 'dict':
         return DictSetStorage(config)
     if tp == 'redis':
-        return RedisSetStorage(config)
+        return RedisSetStorage(config, name=name)
 
 
 class Storage(ABC):

--- a/datasketch/storage.py
+++ b/datasketch/storage.py
@@ -1,0 +1,250 @@
+from collections import defaultdict
+import redis
+import os
+import random
+import string
+from abc import ABCMeta, abstractmethod
+ABC = ABCMeta('ABC', (object,), {}) # compatible with Python 2 *and* 3
+
+
+def ordered_storage(config):
+    '''Return ordered storage system based on the specified config'''
+    tp = config['type']
+    if tp == 'dict':
+        return DictListStorage(config)
+    if tp == 'redis':
+        return RedisListStorage(config)
+
+
+def unordered_storage(config):
+    '''Return an unordered storage system based on the specified config'''
+    tp = config['type']
+    if tp == 'dict':
+        return DictSetStorage(config)
+    if tp == 'redis':
+        return RedisSetStorage(config)
+
+
+class Storage(ABC):
+    def __getitem__(self, key):
+        return self.get(key)
+
+    def __delitem__(self, key):
+        return self.remove(key)
+
+    def __len__(self):
+        return self.size()
+
+    def __iter__(self):
+        for key in self.keys():
+            yield key
+
+    def __contains__(self, item):
+        return self.has_key(item)
+
+    @abstractmethod
+    def keys(self):
+        '''Return an iterator on keys in storage'''
+        return []
+
+    @abstractmethod
+    def get(self, key):
+        '''Get list of values associated with a key
+        
+        Returns empty list ([]) if `key` is not found
+        '''
+        pass
+
+    def getmany(self, *keys):
+        return [self.get(key) for key in keys]
+
+    @abstractmethod
+    def insert(self, key, *vals, **kwargs):
+        '''Add `val` to storage against `key`'''
+        pass
+
+    @abstractmethod
+    def remove(self, *keys):
+        '''Remove `keys` from storage'''
+        pass
+
+    @abstractmethod
+    def remove_val(self, key, val):
+        '''Remove `val` from list of values under `key`'''
+        pass
+
+    @abstractmethod
+    def size(self):
+        '''Return size of storage with respect to number of keys'''
+        pass
+
+    @abstractmethod
+    def has_key(self, key):
+        '''Determines whether the key is in the storage or not'''
+        pass
+
+    def status(self):
+        return {'keyspace_size': len(self)}
+
+
+class OrderedStorage(Storage):
+
+    pass
+
+
+class UnorderedStorage(Storage):
+
+    pass
+
+
+class DictListStorage(OrderedStorage):
+    def __init__(self, config):
+        self._dict = defaultdict(list)
+
+    def keys(self):
+        return self._dict.keys()
+
+    def get(self, key):
+        return self._dict.get(key, [])
+
+    def remove(self, *keys):
+        for key in keys:
+            del self._dict[key]
+
+    def remove_val(self, key, val):
+        self._dict[key].remove(val)
+
+    def insert(self, key, *vals, **kwargs):
+        self._dict[key].extend(vals)
+
+    def size(self):
+        return len(self._dict)
+
+    def has_key(self, key):
+        return key in self._dict
+
+
+class DictSetStorage(UnorderedStorage, DictListStorage):
+    def __init__(self, config):
+        self._dict = defaultdict(set)
+
+    def get(self, key):
+        return self._dict.get(key, set())
+
+    def insert(self, key, *vals, **kwargs):
+        self._dict[key].update(vals)
+
+
+class RedisStorage:
+
+    def __init__(self, config, name=None):
+        self.config = config
+        redis_param = self._parse_config(self.config['redis'])
+        self._redis = redis.Redis(**redis_param)
+        if name is None:
+            name = _random_name(11)
+        self._name = name
+
+    def redis_key(self, key):
+        return self._name + key
+
+    def _parse_config(self, config):
+        cfg = {}
+        for key, value in config.items():
+            if isinstance(value, dict):
+                if 'env' in value:
+                    value = os.getenv(value['env'], value.get('default', None))
+            cfg[key] = value
+        return cfg
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state.pop('_redis')
+        return state
+
+    def __setstate__(self, state):
+        self.__dict__ = state
+        self.__init__(self.config, name=self._name)
+
+
+class RedisListStorage(OrderedStorage, RedisStorage):
+
+    def keys(self):
+        return self._redis.hkeys(self._name)
+
+    def redis_keys(self):
+        return self._redis.hvals(self._name)
+
+    def status(self):
+        status = self._parse_config(self.config['redis'])
+        status.update(Storage.status(self))
+        return status
+
+    def get(self, key):
+        return self._get_items(self._redis, self.redis_key(key))
+
+    def getmany(self, *keys):
+        pipe = self._redis.pipeline()
+        pipe.multi()
+        for key in keys:
+            pipe.lrange(self.redis_key(key), 0, -1)
+        return pipe.execute()
+
+    @staticmethod
+    def _get_items(r, k):
+        return r.lrange(k, 0, -1)
+
+    def remove(self, *keys):
+        self._redis.hdel(self._name, *keys)
+        self._redis.delete(*[self.redis_key(key) for key in keys])
+
+    def remove_val(self, key, val):
+        redis_key = self.redis_key(key)
+        self._redis.lrem(redis_key, val)
+        if not self._redis.exists(redis_key):
+            self._redis.hdel(self._name, redis_key)
+
+    def insert(self, key, *vals, **kwargs):
+        self._insert(self._redis, key, *vals)
+
+    def _insert(self, r, key, *values):
+        redis_key = self.redis_key(key)
+        r.hset(self._name, key, redis_key)
+        r.rpush(redis_key, *values)
+
+    def size(self):
+        return self._redis.hlen(self._name)
+
+    @staticmethod
+    def _get_len(r, k):
+        return r.llen(k)
+
+    def has_key(self, key):
+        return self._redis.hexists(self._name, key)
+
+
+class RedisSetStorage(UnorderedStorage, RedisListStorage):
+
+    @staticmethod
+    def _get_items(r, k):
+        return r.smembers(k)
+
+    def remove_val(self, key, val):
+        redis_key = self.redis_key(key)
+        self._redis.srem(redis_key, val)
+        if not self._redis.exists(redis_key):
+            self._redis.hdel(self._name, redis_key)
+
+    def _insert(self, r, key, *values):
+        redis_key = self.redis_key(key)
+        r.hset(self._name, key, redis_key)
+        r.sadd(redis_key, *values)
+
+    @staticmethod
+    def _get_len(r, k):
+        return r.scard(k)
+
+
+def _random_name(length):
+    return ''.join(random.choice(string.ascii_lowercase)
+                   for _ in range(length)).encode('utf8')

--- a/docsrc/lsh.rst
+++ b/docsrc/lsh.rst
@@ -85,3 +85,35 @@ See :ref:`minhash_lsh_forest` for an alternative.
 In addition, Jaccard similarity may not be the best measure if your intention is to
 find sets having high intersection with the query.
 For intersection search, see :ref:`minhash_lsh_ensemble`.
+
+MinHash LSH at scale
+--------------------
+MinHash LSH supports a Redis backend for querying large datasets as part of
+a production environment. The Redis storage backend is supported using
+
+.. code:: python
+
+      from datasketch import MinHashLSH
+
+      lsh = MinHashLSH(
+         threshold=0.5, num_perm=128, storage_config={
+            'type': 'redis',
+            'redis': {'host': 'localhost', 'port': 6379
+         })
+
+To insert a large number of MinHashes in sequence, it is advisable to use
+an insertion session. This reduces the number of network calls during
+bulk insertion.
+
+Note that for the Redis storage, keys must be ``bytes`` objects.
+
+.. code:: python
+
+      data_list = [("m1", m1), ("m2", m2), ("m3", m3)]
+
+      with lsh.insertion_session() as session:
+         for key, minhash in data_list:
+            session.insert(key, minhash)
+
+Note that querying the LSH object during an open insertion session may result in
+inconsistency.

--- a/docsrc/lsh.rst
+++ b/docsrc/lsh.rst
@@ -98,7 +98,7 @@ a production environment. The Redis storage backend is supported using
       lsh = MinHashLSH(
          threshold=0.5, num_perm=128, storage_config={
             'type': 'redis',
-            'redis': {'host': 'localhost', 'port': 6379
+            'redis': {'host': 'localhost', 'port': 6379}
          })
 
 To insert a large number of MinHashes in sequence, it is advisable to use

--- a/docsrc/lsh.rst
+++ b/docsrc/lsh.rst
@@ -90,8 +90,10 @@ For intersection search, see :ref:`minhash_lsh_ensemble`.
 
 MinHash LSH at scale
 --------------------
-MinHash LSH supports a Redis backend for querying large datasets as part of
-a production environment. The Redis storage backend is supported using
+MinHash LSH supports using Redis as the storage layer for handling large index and 
+providing optional persistence as part of
+a production environment. 
+The Redis storage option can be configured using:
 
 .. code:: python
 
@@ -102,6 +104,10 @@ a production environment. The Redis storage backend is supported using
             'type': 'redis',
             'redis': {'host': 'localhost', 'port': 6379}
          })
+
+Starting multiple MinHash LSH objects across different Python processes sharing 
+the same storage layer can be achieved through "pickling" of an initialized
+LSH object. You can also persist the index connection using `pickle`.
 
 To insert a large number of MinHashes in sequence, it is advisable to use
 an insertion session. This reduces the number of network calls during

--- a/docsrc/lsh.rst
+++ b/docsrc/lsh.rst
@@ -105,8 +105,6 @@ To insert a large number of MinHashes in sequence, it is advisable to use
 an insertion session. This reduces the number of network calls during
 bulk insertion.
 
-Note that for the Redis storage, keys must be ``bytes`` objects.
-
 .. code:: python
 
       data_list = [("m1", m1), ("m2", m2), ("m3", m3)]

--- a/docsrc/lsh.rst
+++ b/docsrc/lsh.rst
@@ -86,6 +86,8 @@ In addition, Jaccard similarity may not be the best measure if your intention is
 find sets having high intersection with the query.
 For intersection search, see :ref:`minhash_lsh_ensemble`.
 
+.. _minhash_lsh_at_scale:
+
 MinHash LSH at scale
 --------------------
 MinHash LSH supports a Redis backend for querying large datasets as part of

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy>=1.11'],
+    install_requires=['numpy>=1.11', 'redis>=2.10.0'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,
@@ -82,7 +82,7 @@ setup(
     # $ pip install -e .[dev,test]
     extras_require={
         'dev': ['check-manifest'],
-        'test': ['coverage'],
+        'test': ['coverage', 'mock>=2.0.0'],
     },
 
     # If there are data files included in your packages that need to be

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
     # $ pip install -e .[dev,test]
     extras_require={
         'dev': ['check-manifest'],
-        'test': ['coverage', 'mock>=2.0.0'],
+        'test': ['coverage', 'mock>=2.0.0', 'mockredispy'],
     },
 
     # If there are data files included in your packages that need to be

--- a/test/lsh_test.py
+++ b/test/lsh_test.py
@@ -73,7 +73,7 @@ class TestMinHashLSH(unittest.TestCase):
         m2.update("b".encode("utf8"))
         lsh.insert("a", m1)
         lsh.insert("b", m2)
-        
+
         lsh.remove("a")
         self.assertTrue("a" not in lsh.keys)
         for table in lsh.hashtables:
@@ -106,19 +106,19 @@ class TestMinHashLSH(unittest.TestCase):
             m1.update("a".encode("utf8"))
             m2 = MinHash(16)
             m2.update("b".encode("utf8"))
-            lsh.insert(b"a", m1)
-            lsh.insert(b"b", m2)
+            lsh.insert("a", m1)
+            lsh.insert("b", m2)
             for t in lsh.hashtables:
                 self.assertTrue(len(t) >= 1)
                 items = []
                 for H in t:
                     items.extend(t[H])
-                self.assertTrue(b"a" in items)
-                self.assertTrue(b"b" in items)
-            self.assertTrue(b"a" in lsh)
-            self.assertTrue(b"b" in lsh)
-            for i, H in enumerate(lsh.keys[b"a"]):
-                self.assertTrue(b"a" in lsh.hashtables[i][H])
+                self.assertTrue("a" in items)
+                self.assertTrue("b" in items)
+            self.assertTrue("a" in lsh)
+            self.assertTrue("b" in lsh)
+            for i, H in enumerate(lsh.keys["a"]):
+                self.assertTrue("a" in lsh.hashtables[i][H])
 
             m3 = MinHash(18)
             self.assertRaises(ValueError, lsh.insert, "c", m3)
@@ -132,12 +132,12 @@ class TestMinHashLSH(unittest.TestCase):
             m1.update("a".encode("utf8"))
             m2 = MinHash(16)
             m2.update("b".encode("utf8"))
-            lsh.insert(b"a", m1)
-            lsh.insert(b"b", m2)
+            lsh.insert("a", m1)
+            lsh.insert("b", m2)
             result = lsh.query(m1)
-            self.assertTrue(b"a" in result)
+            self.assertTrue("a" in result)
             result = lsh.query(m2)
-            self.assertTrue(b"b" in result)
+            self.assertTrue("b" in result)
 
             m3 = MinHash(18)
             self.assertRaises(ValueError, lsh.query, m3)

--- a/test/lsh_test.py
+++ b/test/lsh_test.py
@@ -113,12 +113,12 @@ class TestMinHashLSH(unittest.TestCase):
                 items = []
                 for H in t:
                     items.extend(t[H])
-                self.assertTrue("a" in items)
-                self.assertTrue("b" in items)
+                self.assertTrue(pickle.dumps("a") in items)
+                self.assertTrue(pickle.dumps("b") in items)
             self.assertTrue("a" in lsh)
             self.assertTrue("b" in lsh)
-            for i, H in enumerate(lsh.keys["a"]):
-                self.assertTrue("a" in lsh.hashtables[i][H])
+            for i, H in enumerate(lsh.keys[pickle.dumps("a")]):
+                self.assertTrue(pickle.dumps("a") in lsh.hashtables[i][H])
 
             m3 = MinHash(18)
             self.assertRaises(ValueError, lsh.insert, "c", m3)

--- a/test/lshensemble_test.py
+++ b/test/lshensemble_test.py
@@ -42,4 +42,4 @@ class TestMinHashLSHEnsemble(unittest.TestCase):
         for key, minhash, size in data:
             keys1 = lsh.query(minhash, size)
             keys2 = lsh2.query(minhash, size)
-            self.assertTrue(all(k1 == k2 for k1, k2 in zip(keys1, keys2)))
+            self.assertTrue(set(keys1) == set(keys2))


### PR DESCRIPTION
## Summary
We have been using datasketch extensively in data-driven applications (primarily the `MinHashLSH` class). The existing implementation requires all data to be stored in memory, which is a severe limitation for very large datasets. We add support for a Redis backend. Default behavior remains in-memory storage.

## Changes
 - Redis backend for `MinHashLSH`
 - Insertion session for bulk insertion (reduces network calls when inserting with a Redis backend)
 - Functionality to view LSH bucket sizes (useful for diagnosis/debugging)
 - Accompanying docs and tests

## Examples
For examples, see the additions to the documentation.