### PR TITLE
Fix a bug with RedisSetStorage.getmany

### DIFF
--- a/datasketch/storage.py
+++ b/datasketch/storage.py
@@ -329,7 +329,7 @@ if redis is not None:
             pipe = self._redis.pipeline()
             pipe.multi()
             for key in keys:
-                pipe.lrange(self.redis_key(key), 0, -1)
+                self._get_items(pipe, self.redis_key(key))
             return pipe.execute()
 
         @staticmethod


### PR DESCRIPTION
Noticed a bug with the Redis implementation of `getmany` for set storage.