### PR TITLE
Use Murmur3 hash function as default, remove hashobj parameter.

### DIFF
--- a/benchmark/b_bit_minhash_benchmark.py
+++ b/benchmark/b_bit_minhash_benchmark.py
@@ -13,8 +13,8 @@ from similarity_benchmark import _get_exact, _gen_data,\
 def _run_minhash(A, B, data, seed, bs, num_perm):
     (a_start, a_end), (b_start, b_end) = A, B
     hasher = pyhash.murmur3_32()
-    m1 = MinHash(num_perm=num_perm, hashobj=Hash)
-    m2 = MinHash(num_perm=num_perm, hashobj=Hash)
+    m1 = MinHash(num_perm=num_perm)
+    m2 = MinHash(num_perm=num_perm)
     for i in xrange(a_start, a_end):
         m1.update(hasher(data[i], seed=seed))
     for i in xrange(b_start, b_end):

--- a/benchmark/cardinality_benchmark.py
+++ b/benchmark/cardinality_benchmark.py
@@ -1,5 +1,4 @@
 import time, logging, random, struct
-import pyhash
 from datasketch.hyperloglog import HyperLogLog
 from datasketch.minhash import MinHash
 
@@ -8,34 +7,26 @@ logging.basicConfig(level=logging.INFO)
 # Produce some bytes
 int_bytes = lambda x : ("a-%d-%d" % (x, x)).encode('utf-8')
 
-class Hash(object):
-    def __init__(self, h):
-        self.h = h
-    def digest(self):
-        return struct.pack('<I', self.h)
-
 def _gen_data(size):
     return [int_bytes(i) for i in range(size)]
 
 def _run_hyperloglog(data, seed, p):
-    hasher = pyhash.murmur3_32()
-    h = HyperLogLog(p=p, hashobj=Hash)
+    h = HyperLogLog(p=p)
     for d in data:
-        h.update(hasher(d, seed=seed))
+        h.update(d)
     return h.count()
 
 def _run_minhash(data, seed, p):
-    hasher = pyhash.murmur3_32()
-    m = MinHash(num_perm=2**p, hashobj=Hash)
+    m = MinHash(num_perm=2**p, seed=seed)
     for d in data:
-        m.update(hasher(d, seed=seed))
+        m.update(d)
     return m.count()
 
 def _run_test(data, n, p):
     logging.info("Running HyperLogLog with p = %d" % p)
-    hll_runs = [_run_hyperloglog(data, i, p) for i in xrange(n)]
+    hll_runs = [_run_hyperloglog(data, i, p) for i in range(n)]
     logging.info("Running MinHash with num_perm = %d" % 2**p)
-    minhash_runs = [_run_minhash(data, i, p) for i in xrange(n)]
+    minhash_runs = [_run_minhash(data, i, p) for i in range(n)]
     return (hll_runs, minhash_runs)
 
 

--- a/benchmark/hyperloglog_benchmark.py
+++ b/benchmark/hyperloglog_benchmark.py
@@ -12,9 +12,10 @@ int_bytes = lambda x : ("a-%d-%d" % (x, x)).encode('utf-8')
 def run_perf(card, p):
     h = HyperLogLog(p=p)
     logging.info("HyperLogLog using p = %d " % p)
+    s = ["a-%d-%d" % (x, x) for x in range(card)]
     start = time.clock()
-    for i in range(card):
-        h.update(int_bytes(i))
+    for b in s:
+        h.update(b)
     duration = time.clock() - start
     logging.info("Digested %d hashes in %.4f sec" % (card, duration))
     return duration

--- a/benchmark/inclusion_benchmark.py
+++ b/benchmark/inclusion_benchmark.py
@@ -1,13 +1,11 @@
 '''
 Test the accuracy of inclusion estimation using data sketches
-Must be using Python 2 as pyhash does not support Python 3
 HyperLogLog inclusion score is computed using cardinality estimate
 and inclusion-exclusion principle.
 MinHash inclusion score is computed using Jaccard estiamte,
 inclusion-exclusion principle, and the exact cardinality.
 '''
 import time, logging, random, struct
-import pyhash
 from datasketch.hyperloglog import HyperLogLog
 from datasketch.minhash import MinHash
 
@@ -50,31 +48,29 @@ def _hyperloglog_inclusion(h1, h2):
 
 def _run_hyperloglog(A, B, data, seed, p):
     (a_start, a_end), (b_start, b_end) = A, B
-    hasher = pyhash.murmur3_32()
-    h1 = HyperLogLog(p=p, hashobj=Hash)
-    h2 = HyperLogLog(p=p, hashobj=Hash)
-    for i in xrange(a_start, a_end):
-        h1.update(hasher(data[i], seed=seed))
-    for i in xrange(b_start, b_end):
-        h2.update(hasher(data[i], seed=seed))
+    h1 = HyperLogLog(p=p)
+    h2 = HyperLogLog(p=p)
+    for i in range(a_start, a_end):
+        h1.update(data[i])
+    for i in range(b_start, b_end):
+        h2.update(data[i])
     return _hyperloglog_inclusion(h1, h2)
 
 def _run_minhash(A, B, data, seed, p):
     (a_start, a_end), (b_start, b_end) = A, B
-    hasher = pyhash.murmur3_32()
-    m1 = MinHash(num_perm=2**p, hashobj=Hash)
-    m2 = MinHash(num_perm=2**p, hashobj=Hash)
-    for i in xrange(a_start, a_end):
-        m1.update(hasher(data[i], seed=seed))
-    for i in xrange(b_start, b_end):
-        m2.update(hasher(data[i], seed=seed))
+    m1 = MinHash(num_perm=2**p)
+    m2 = MinHash(num_perm=2**p)
+    for i in range(a_start, a_end):
+        m1.update(data[i])
+    for i in range(b_start, b_end):
+        m2.update(data[i])
     return _minhash_inclusion(m1, m2)
 
 def _run_test(A, B, data, n, p):
     logging.info("Running HyperLogLog with p = %d" % p)
-    hll_runs = [_run_hyperloglog(A, B, data, i, p) for i in xrange(n)]
+    hll_runs = [_run_hyperloglog(A, B, data, i, p) for i in range(n)]
     logging.info("Running MinHash with num_perm = %d" % 2**p)
-    minhash_runs = [_run_minhash(A, B, data, i, p) for i in xrange(n)]
+    minhash_runs = [_run_minhash(A, B, data, i, p) for i in range(n)]
     return (hll_runs, minhash_runs)
 
 

--- a/benchmark/inclusion_benchmark.py
+++ b/benchmark/inclusion_benchmark.py
@@ -6,6 +6,7 @@ MinHash inclusion score is computed using Jaccard estiamte,
 inclusion-exclusion principle, and the exact cardinality.
 '''
 import time, logging, random, struct
+import mmh3
 from datasketch.hyperloglog import HyperLogLog
 from datasketch.minhash import MinHash
 
@@ -47,9 +48,12 @@ def _hyperloglog_inclusion(h1, h2):
     return ic / c1
 
 def _run_hyperloglog(A, B, data, seed, p):
+    class H(HyperLogLog):
+        def hash_func(self, b):
+            return mmh3.hash(b, seed=seed, signed=False)
     (a_start, a_end), (b_start, b_end) = A, B
-    h1 = HyperLogLog(p=p)
-    h2 = HyperLogLog(p=p)
+    h1 = H(p=p)
+    h2 = H(p=p)
     for i in range(a_start, a_end):
         h1.update(data[i])
     for i in range(b_start, b_end):
@@ -57,9 +61,12 @@ def _run_hyperloglog(A, B, data, seed, p):
     return _hyperloglog_inclusion(h1, h2)
 
 def _run_minhash(A, B, data, seed, p):
+    class M(MinHash):
+        def hash_func(self, b):
+            return mmh3.hash(b, seed=seed, signed=False)
     (a_start, a_end), (b_start, b_end) = A, B
-    m1 = MinHash(num_perm=2**p)
-    m2 = MinHash(num_perm=2**p)
+    m1 = M(num_perm=2**p)
+    m2 = M(num_perm=2**p)
     for i in range(a_start, a_end):
         m1.update(data[i])
     for i in range(b_start, b_end):

--- a/benchmark/minhash_benchmark.py
+++ b/benchmark/minhash_benchmark.py
@@ -17,9 +17,10 @@ int_bytes = lambda x : ("a-%d-%d" % (x, x)).encode('utf-8')
 def run_perf(card, num_perm):
     m = MinHash(num_perm=num_perm)
     logging.info("MinHash using %d permutation functions" % num_perm)
+    s = ["a-%d-%d" % (x, x) for x in range(card)]
     start = time.clock()
-    for i in range(card):
-        m.update(int_bytes(i))
+    for b in s:
+        m.update(b)
     duration = time.clock() - start
     logging.info("Digested %d hashes in %.4f sec" % (card, duration))
     return duration

--- a/benchmark/similarity_benchmark.py
+++ b/benchmark/similarity_benchmark.py
@@ -1,9 +1,7 @@
 '''
-Test the accuracy of similarity estimation using data sketches
-Must be using Python 2 as pyhash does not support Python 3
+Test the accuracy of similarity estimation using data sketches.
 '''
 import time, logging, random, struct
-import pyhash
 import numpy as np
 from datasketch.hyperloglog import HyperLogLog
 from datasketch.minhash import MinHash
@@ -13,12 +11,6 @@ logging.basicConfig(level=logging.INFO)
 
 # Produce some bytes
 int_bytes = lambda x : ("a-%d-%d" % (x, x)).encode('utf-8')
-
-class Hash(object):
-    def __init__(self, h):
-        self.h = h
-    def digest(self):
-        return struct.pack('<I', self.h)
 
 def _gen_data(size):
     return [int_bytes(i) for i in range(size)]
@@ -46,33 +38,31 @@ def _b_bit_minhash_jaccard(m1, m2, b):
 
 def _run_minhash(A, B, data, seed, num_perm, b):
     (a_start, a_end), (b_start, b_end) = A, B
-    hasher = pyhash.murmur3_32()
-    m1 = MinHash(num_perm=num_perm, hashobj=Hash)
-    m2 = MinHash(num_perm=num_perm, hashobj=Hash)
-    for i in xrange(a_start, a_end):
-        m1.update(hasher(data[i], seed=seed))
-    for i in xrange(b_start, b_end):
-        m2.update(hasher(data[i], seed=seed))
+    m1 = MinHash(num_perm=num_perm, seed=seed)
+    m2 = MinHash(num_perm=num_perm, seed=seed)
+    for i in range(a_start, a_end):
+        m1.update(data[i])
+    for i in range(b_start, b_end):
+        m2.update(data[i])
     return [m1.jaccard(m2), _b_bit_minhash_jaccard(m1, m2, b)]
 
 def _run_hyperloglog(A, B, data, seed, p):
     (a_start, a_end), (b_start, b_end) = A, B
-    hasher = pyhash.murmur3_32()
-    h1 = HyperLogLog(p=p, hashobj=Hash)
-    h2 = HyperLogLog(p=p, hashobj=Hash)
-    for i in xrange(a_start, a_end):
-        h1.update(hasher(data[i], seed=seed))
-    for i in xrange(b_start, b_end):
-        h2.update(hasher(data[i], seed=seed))
+    h1 = HyperLogLog(p=p)
+    h2 = HyperLogLog(p=p)
+    for i in range(a_start, a_end):
+        h1.update(data[i])
+    for i in range(b_start, b_end):
+        h2.update(data[i])
     return _hyperloglog_jaccard(h1, h2)
 
 def _run_test(A, B, data, n, p, num_perm, b):
     logging.info("Running MinHash with num_perm = %d" % num_perm)
     minhash_runs, bbit_runs = np.array([_run_minhash(A, B, data,
             i, num_perm, b)
-        for i in xrange(n)]).T
+        for i in range(n)]).T
     logging.info("Running HyperLogLog with p = %d" % p)
-    hll_runs = [_run_hyperloglog(A, B, data, i, p) for i in xrange(n)]
+    hll_runs = [_run_hyperloglog(A, B, data, i, p) for i in range(n)]
     return (minhash_runs, bbit_runs, hll_runs)
 
 

--- a/datasketch/hyperloglog.py
+++ b/datasketch/hyperloglog.py
@@ -75,6 +75,17 @@ class HyperLogLog(object):
         self.max_rank = self._hash_range_bit - self.p
 
     def _hash_func(self, b):
+        '''The Murmur3 32-bit hash function used compute the hash value of
+        the input to `update`.
+
+        You can override this function to use a different hash function.
+
+        Args:
+            b (byte-like): The value of type `bytes` or byte-like such as `str`.
+
+        Returns:
+            unsigned int: The hash value.
+        '''
         return mmh3.hash(b) & 0xffffffff
 
     def update(self, b):
@@ -92,7 +103,7 @@ class HyperLogLog(object):
                 hyperloglog.update("new value".encode('utf-8'))
         '''
         # Compute the hash function to get the hash value
-        hv = self._hash_func(b)
+        hv = self.hash_func(b)
         # Get the index of the register using the first p bits of the hash
         reg_index = hv & (self.m - 1)
         # Get the rest of the hash
@@ -286,7 +297,18 @@ class HyperLogLogPlusPlus(HyperLogLog):
 
     _hash_range_bit = 64
 
-    def _hash_func(self, b):
+    def hash_func(self, b):
+        '''The Murmur3 64-bit hash function used compute the hash value of
+        the input to `update`.
+
+        You can override this function to use a different hash function.
+
+        Args:
+            b (byte-like): The value of type `bytes` or byte-like such as `str`.
+
+        Returns:
+            unsigned int: The hash value.
+        '''
         return mmh3.hash64(b)[0] & 0xffffffffffffffff
 
     def _get_threshold(self, p):

--- a/datasketch/hyperloglog.py
+++ b/datasketch/hyperloglog.py
@@ -74,6 +74,9 @@ class HyperLogLog(object):
         self.alpha = self._get_alpha(self.p)
         self.max_rank = self._hash_range_bit - self.p
 
+    def _hash_func(self, b):
+        return mmh3.hash(b) & 0xffffffff
+
     def update(self, b):
         '''
         Update the HyperLogLog with a new data value in bytes.
@@ -88,8 +91,8 @@ class HyperLogLog(object):
 
                 hyperloglog.update("new value".encode('utf-8'))
         '''
-        # Digest the hash object to get the hash value
-        hv = _hash_func(b)
+        # Compute the hash function to get the hash value
+        hv = self._hash_func(b)
         # Get the index of the register using the first p bits of the hash
         reg_index = hv & (self.m - 1)
         # Get the rest of the hash
@@ -282,8 +285,9 @@ class HyperLogLogPlusPlus(HyperLogLog):
     '''
 
     _hash_range_bit = 64
-    # The hash function used by HyperLogLog++
-    _hash_func = lambda b : mmh3.hash64(b, signed=False)[0]
+
+    def _hash_func(self, b):
+        return mmh3.hash64(b)[0] & 0xffffffffffffffff
 
     def _get_threshold(self, p):
         return _thresholds[p - 4]

--- a/datasketch/lean_minhash.py
+++ b/datasketch/lean_minhash.py
@@ -9,7 +9,7 @@ class LeanMinHash(MinHash):
     -- no `update()`.
 
     Lean MinHash inherits all methods from :class:`datasketch.MinHash`.
-    It does not store the `permutations` and the `hashobj` needed for updating.
+    It does not store the `permutations` needed for updating.
     If a MinHash does not need further updates, convert it into a lean MinHash
     to save memory.
 
@@ -213,7 +213,7 @@ class LeanMinHash(MinHash):
         seed = lmhs[0].seed
         if any((seed != m.seed or num_perm != len(m)) for m in lmhs):
             raise ValueError("The unioning MinHash must have the\
-                    same seed, number of permutation functions and hashobj")
+                    same seed and number of permutation functions")
         hashvalues = np.minimum.reduce([m.hashvalues for m in lmhs])
 
         lmh = object.__new__(LeanMinHash)

--- a/datasketch/minhash.py
+++ b/datasketch/minhash.py
@@ -1,5 +1,4 @@
 import random, copy, struct
-from hashlib import sha1
 import numpy as np
 import mmh3
 
@@ -98,7 +97,7 @@ class MinHash(object):
 
                 minhash.update("new value".encode('utf-8'))
         '''
-        hv = mmh3.hash(b, signed=False)
+        hv = mmh3.hash(b) & 0xffffffff
         a, b = self.permutations
         phv = np.bitwise_and((a * hv + b) % _mersenne_prime, np.uint64(_max_hash))
         self.hashvalues = np.minimum(phv, self.hashvalues)

--- a/datasketch/minhash.py
+++ b/datasketch/minhash.py
@@ -84,11 +84,25 @@ class MinHash(object):
     def _parse_hashvalues(self, hashvalues):
         return np.array(hashvalues, dtype=np.uint64)
 
+    def hash_func(self, b):
+        '''The Murmur3 32-bit hash function used compute the hash value of
+        the input to `update` before applying permutations.
+
+        You can override this function to use a different hash function.
+
+        Args:
+            b (byte-like): The value of type `bytes` or byte-like such as `str`.
+
+        Returns:
+            unsigned int: The hash value.
+        '''
+        return mmh3.hash(b) & 0xffffffff
+
     def update(self, b):
         '''Update this MinHash with a new value.
 
         Args:
-            b (bytes): The value of type `bytes`.
+            b (byte-like): The value of type `bytes` or byte-like such as `str`.
 
         Example:
             To update with a new string value:
@@ -97,7 +111,7 @@ class MinHash(object):
 
                 minhash.update("new value".encode('utf-8'))
         '''
-        hv = mmh3.hash(b) & 0xffffffff
+        hv = self.hash_func(b)
         a, b = self.permutations
         phv = np.bitwise_and((a * hv + b) % _mersenne_prime, np.uint64(_max_hash))
         self.hashvalues = np.minimum(phv, self.hashvalues)

--- a/datasketch/minhash.py
+++ b/datasketch/minhash.py
@@ -1,6 +1,7 @@
 import random, copy, struct
 from hashlib import sha1
 import numpy as np
+import mmh3
 
 # The size of a hash value in number of bytes
 hashvalue_byte_size = len(bytes(np.int64(42).data))
@@ -11,49 +12,45 @@ _max_hash = (1 << 32) - 1
 _hash_range = (1 << 32)
 
 class MinHash(object):
-    '''MinHash is a probabilistic data structure for computing 
+    '''MinHash is a probabilistic data structure for computing
     `Jaccard similarity`_ between sets.
- 
+
     Args:
         num_perm (int, optional): Number of random permutation functions.
             It will be ignored if `hashvalues` is not None.
-        seed (int, optional): The random seed controls the set of random 
+        seed (int, optional): The random seed controls the set of random
             permutation functions generated for this MinHash.
-        hashobj (optional): The hash function used by this MinHash. 
-            It must implements
-            the `digest()` method similar to hashlib_ hash functions, such
-            as `hashlib.sha1`.
-        hashvalues (`numpy.array` or `list`, optional): The hash values is 
-            the internal state of the MinHash. It can be specified for faster 
-            initialization using the existing state from another MinHash. 
+        hashvalues (`numpy.array` or `list`, optional): The hash values is
+            the internal state of the MinHash. It can be specified for faster
+            initialization using the existing state from another MinHash.
         permutations (optional): The permutation function parameters. This argument
             can be specified for faster initialization using the existing
             state from another MinHash.
-    
-    Note:
-        To save memory usage, consider using :class:`datasketch.LeanMinHash`.
-        
-    Note:
-        Since version 1.1.1, MinHash will only support serialization using 
-        `pickle`_. ``serialize`` and ``deserialize`` methods are removed, 
-        and are supported in :class:`datasketch.LeanMinHash` instead. 
-        MinHash serialized before version 1.1.1 cannot be deserialized properly 
-        in newer versions (`need to migrate? <https://github.com/ekzhu/datasketch/issues/18>`_). 
 
     Note:
-        Since version 1.1.3, MinHash uses Numpy's random number generator 
-        instead of Python's built-in random package. This change makes the 
+        To save memory usage, consider using :class:`datasketch.LeanMinHash`.
+
+    Note:
+        Since version 1.1.1, MinHash will only support serialization using
+        `pickle`_. ``serialize`` and ``deserialize`` methods are removed,
+        and are supported in :class:`datasketch.LeanMinHash` instead.
+        MinHash serialized before version 1.1.1 cannot be deserialized properly
+        in newer versions (`need to migrate? <https://github.com/ekzhu/datasketch/issues/18>`_).
+
+    Note:
+        Since version 1.1.3, MinHash uses Numpy's random number generator
+        instead of Python's built-in random package. This change makes the
         hash values consistent across different Python versions.
         The side-effect is that now MinHash created before version 1.1.3 won't
         work (i.e., ``jaccard``, ``merge`` and ``union``)
-        with those created after. 
+        with those created after.
 
     .. _`Jaccard similarity`: https://en.wikipedia.org/wiki/Jaccard_index
     .. _hashlib: https://docs.python.org/3.5/library/hashlib.html
     .. _`pickle`: https://docs.python.org/3/library/pickle.html
     '''
 
-    def __init__(self, num_perm=128, seed=1, hashobj=sha1,
+    def __init__(self, num_perm=128, seed=1,
             hashvalues=None, permutations=None):
         if hashvalues is not None:
             num_perm = len(hashvalues)
@@ -63,7 +60,6 @@ class MinHash(object):
             raise ValueError("Cannot have more than %d number of\
                     permutation functions" % _hash_range)
         self.seed = seed
-        self.hashobj = hashobj
         # Initialize hash values
         if hashvalues is not None:
             self.hashvalues = self._parse_hashvalues(hashvalues)
@@ -91,18 +87,18 @@ class MinHash(object):
 
     def update(self, b):
         '''Update this MinHash with a new value.
-        
+
         Args:
             b (bytes): The value of type `bytes`.
-            
+
         Example:
             To update with a new string value:
-            
+
             .. code-block:: python
 
                 minhash.update("new value".encode('utf-8'))
         '''
-        hv = struct.unpack('<I', self.hashobj(b).digest()[:4])[0]
+        hv = mmh3.hash(b, signed=False)
         a, b = self.permutations
         phv = np.bitwise_and((a * hv + b) % _mersenne_prime, np.uint64(_max_hash))
         self.hashvalues = np.minimum(phv, self.hashvalues)
@@ -110,10 +106,10 @@ class MinHash(object):
     def jaccard(self, other):
         '''Estimate the `Jaccard similarity`_ (resemblance) between the sets
         represented by this MinHash and the other.
-        
+
         Args:
             other (datasketch.MinHash): The other MinHash.
-            
+
         Returns:
             float: The Jaccard similarity, which is between 0.0 and 1.0.
         '''
@@ -129,7 +125,7 @@ class MinHash(object):
     def count(self):
         '''Estimate the cardinality count based on the technique described in
         `this paper <http://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=365694>`_.
-        
+
         Returns:
             int: The estimated cardinality of the set represented by this MinHash.
         '''
@@ -139,7 +135,7 @@ class MinHash(object):
     def merge(self, other):
         '''Merge the other MinHash with this one, making this one the union
         of both.
-        
+
         Args:
             other (datasketch.MinHash): The other MinHash.
         '''
@@ -154,7 +150,7 @@ class MinHash(object):
     def digest(self):
         '''Export the hash values, which is the internal state of the
         MinHash.
-        
+
         Returns:
             numpy.array: The hash values which is a Numpy array.
         '''
@@ -162,7 +158,7 @@ class MinHash(object):
 
     def is_empty(self):
         '''
-        Returns: 
+        Returns:
             bool: If the current MinHash is empty - at the state of just
                 initialized.
         '''
@@ -204,7 +200,7 @@ class MinHash(object):
         Args:
             *mhs: The MinHash objects to be united. The argument list length is variable,
                 but must be at least 2.
-        
+
         Returns:
             datasketch.MinHash: A new union MinHash.
         '''

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
 
-    version='1.2.10',
+    version='1.3.0',
 
     description='Probabilistic data structures for processing and searching very large datasets',
     long_description=long_description,
@@ -76,7 +76,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['numpy>=1.11', 'redis>=2.10.0'],
+    install_requires=['numpy>=1.11', 'mmh3>=2.5.1', 'redis>=2.10.0'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/test/hyperloglog_test.py
+++ b/test/hyperloglog_test.py
@@ -1,45 +1,29 @@
 import unittest
 import struct
 import pickle
-from hashlib import sha1
 from mock import patch
 import numpy as np
 from datasketch.hyperloglog import HyperLogLog, HyperLogLogPlusPlus
 
-
-class FakeHash(object):
-    '''
-    Implmenets the hexupdate required by HyperLogLog.
-    '''
-
-    def __init__(self, h):
-        '''
-        Initialize with an integer
-        '''
-        self.h = h
-
-    def digest(self):
-        '''
-        Return the bytes representation of the integer
-        '''
-        return struct.pack('<Q', self.h)
-
+class HyperLogLogFakeHash(HyperLogLog):
+    def _hash_func(self, b):
+        return b & 0xffffffff
 
 class TestHyperLogLog(unittest.TestCase):
 
-    _class = HyperLogLog
+    _class = HyperLogLogFakeHash
 
     def test_init(self):
-        h = self._class(4, hashobj=FakeHash)
+        h = self._class(4)
         self.assertEqual(h.m, 1 << 4)
         self.assertEqual(len(h.reg), h.m)
         self.assertTrue(all(0 == i for i in h.reg))
 
     def test_init_from_reg(self):
         reg = np.array([1 for _ in range(1 << 4)], dtype=np.int8)
-        h = self._class(reg=reg, hashobj=FakeHash)
+        h = self._class(reg=reg)
         self.assertEqual(h.p, 4)
-        h2 = self._class(p=4, hashobj=FakeHash)
+        h2 = self._class(p=4)
         self.assertEqual(h.p, h2.p)
 
     def test_is_empty(self):
@@ -47,7 +31,7 @@ class TestHyperLogLog(unittest.TestCase):
         self.assertTrue(h.is_empty())
 
     def test_update(self):
-        h = self._class(4, hashobj=FakeHash)
+        h = self._class(4)
         h.update(0b00011111)
         self.assertEqual(h.reg[0b1111], self._class._hash_range_bit - 4)
         h.update(0xfffffff1)
@@ -56,8 +40,8 @@ class TestHyperLogLog(unittest.TestCase):
         self.assertEqual(h.reg[5], self._class._hash_range_bit - 4 - 3)
 
     def test_merge(self):
-        h1 = self._class(4, hashobj=FakeHash)
-        h2 = self._class(4, hashobj=FakeHash)
+        h1 = self._class(4)
+        h2 = self._class(4)
         h1.update(0b00011111)
         h2.update(0xfffffff1)
         h1.merge(h2)
@@ -65,7 +49,7 @@ class TestHyperLogLog(unittest.TestCase):
         self.assertEqual(h1.reg[1], 1)
 
     def test_count(self):
-        h = self._class(4, hashobj=FakeHash)
+        h = self._class(4)
         h.update(0b00011111)
         h.update(0xfffffff1)
         h.update(0xfffffff5)
@@ -75,13 +59,13 @@ class TestHyperLogLog(unittest.TestCase):
         h.count()
 
     def test_serialize(self):
-        h = self._class(4, hashobj=FakeHash)
+        h = self._class(4)
         buf = bytearray(h.bytesize())
         h.serialize(buf)
         self.assertEqual(h.p, struct.unpack_from('B', bytes(buf), 0)[0])
 
     def test_deserialize(self):
-        h = self._class(4, hashobj=FakeHash)
+        h = self._class(4)
         h.update(123)
         h.update(33)
         h.update(12)
@@ -94,7 +78,7 @@ class TestHyperLogLog(unittest.TestCase):
         self.assertTrue(all(i == j for i, j in zip(h.reg, hd.reg)))
 
     def test_pickle(self):
-        h = self._class(4, hashobj=FakeHash)
+        h = self._class(4)
         h.update(123)
         h.update(33)
         h.update(12)
@@ -105,9 +89,9 @@ class TestHyperLogLog(unittest.TestCase):
         self.assertTrue(np.array_equal(p.reg, h.reg))
 
     def test_union(self):
-        h1 = self._class(4, hashobj=FakeHash)
-        h2 = self._class(4, hashobj=FakeHash)
-        h3 = self._class(4, hashobj=FakeHash)
+        h1 = self._class(4)
+        h2 = self._class(4)
+        h3 = self._class(4)
         h1.update(0b00011111)
         h2.update(0xfffffff1)
         h3.update(0x000000f5)
@@ -117,10 +101,10 @@ class TestHyperLogLog(unittest.TestCase):
         self.assertEqual(h.reg[5], self._class._hash_range_bit - 4 - 3)
 
     def test_eq(self):
-        h1 = self._class(4, hashobj=FakeHash)
-        h2 = self._class(4, hashobj=FakeHash)
-        h3 = self._class(4, hashobj=FakeHash)
-        h4 = self._class(8, hashobj=FakeHash)
+        h1 = self._class(4)
+        h2 = self._class(4)
+        h3 = self._class(4)
+        h4 = self._class(8)
         h1.update(0b00011111)
         h2.update(0xfffffff1)
         h3.update(0b00011111)
@@ -149,12 +133,17 @@ class TestHyperLogLogSpecific(unittest.TestCase):
         self.assertTrue(mock_method.called)
 
 
+class HyperLogLogPlusPlusFakeHash(HyperLogLogPlusPlus):
+    def _hash_func(self, b):
+        return b & 0xffffffffffffffff
+
+
 class TestHyperLogLogPlusPlus(TestHyperLogLog):
 
-    _class = HyperLogLogPlusPlus
+    _class = HyperLogLogPlusPlusFakeHash
 
     def test_update(self):
-        h = self._class(4, hashobj=FakeHash)
+        h = self._class(4)
         h.update(0b00011111)
         self.assertEqual(h.reg[0b1111], self._class._hash_range_bit - 4)
         h.update(0xfffffffffffffff1)
@@ -163,8 +152,8 @@ class TestHyperLogLogPlusPlus(TestHyperLogLog):
         self.assertEqual(h.reg[5], self._class._hash_range_bit - 4 - 3)
 
     def test_merge(self):
-        h1 = self._class(4, hashobj=FakeHash)
-        h2 = self._class(4, hashobj=FakeHash)
+        h1 = self._class(4)
+        h2 = self._class(4)
         h1.update(0b00011111)
         h2.update(0xfffffffffffffff1)
         h1.merge(h2)
@@ -172,9 +161,9 @@ class TestHyperLogLogPlusPlus(TestHyperLogLog):
         self.assertEqual(h1.reg[1], 1)
 
     def test_union(self):
-        h1 = self._class(4, hashobj=FakeHash)
-        h2 = self._class(4, hashobj=FakeHash)
-        h3 = self._class(4, hashobj=FakeHash)
+        h1 = self._class(4)
+        h2 = self._class(4)
+        h3 = self._class(4)
         h1.update(0b00011111)
         h2.update(0xfffffffffffffff1)
         h3.update(0x000000f5)

--- a/test/hyperloglog_test.py
+++ b/test/hyperloglog_test.py
@@ -6,7 +6,7 @@ import numpy as np
 from datasketch.hyperloglog import HyperLogLog, HyperLogLogPlusPlus
 
 class HyperLogLogFakeHash(HyperLogLog):
-    def _hash_func(self, b):
+    def hash_func(self, b):
         return b & 0xffffffff
 
 class TestHyperLogLog(unittest.TestCase):
@@ -134,7 +134,7 @@ class TestHyperLogLogSpecific(unittest.TestCase):
 
 
 class HyperLogLogPlusPlusFakeHash(HyperLogLogPlusPlus):
-    def _hash_func(self, b):
+    def hash_func(self, b):
         return b & 0xffffffffffffffff
 
 

--- a/test/lean_minhash_test.py
+++ b/test/lean_minhash_test.py
@@ -5,28 +5,11 @@ import numpy as np
 from datasketch import MinHash
 from datasketch import LeanMinHash
 
-class FakeHash(object):
-    '''
-    Implmenets the hexdigest required by HyperLogLog.
-    '''
-
-    def __init__(self, h):
-        '''
-        Initialize with an integer
-        '''
-        self.h = h
-
-    def digest(self):
-        '''
-        Return the bytes representation of the integer
-        '''
-        return struct.pack('<Q', self.h)
-
 class TestLeanMinHash(unittest.TestCase):
 
     def test_init(self):
-        m1 = MinHash(4, 1, hashobj=FakeHash)
-        m2 = MinHash(4, 1, hashobj=FakeHash)
+        m1 = MinHash(4, 1)
+        m2 = MinHash(4, 1)
         lm1 = LeanMinHash(m1)
         lm2 = LeanMinHash(m2)
         self.assertTrue(np.array_equal(lm1.hashvalues, lm2.hashvalues))
@@ -38,59 +21,59 @@ class TestLeanMinHash(unittest.TestCase):
         self.assertTrue(lm.is_empty())
 
     def test_update(self):
-        m1 = MinHash(4, 1, hashobj=FakeHash)
+        m1 = MinHash(4, 1)
         try:
             lm1 = LeanMinHash(m1)
-            lm1.update(12)
+            lm1.update("12")
         except TypeError:
             pass
         else:
             raise Exception
 
     def test_jaccard(self):
-        m1 = MinHash(4, 1, hashobj=FakeHash)
-        m2 = MinHash(4, 1, hashobj=FakeHash)
+        m1 = MinHash(4, 1)
+        m2 = MinHash(4, 1)
         lm1 = LeanMinHash(m1)
         lm2 = LeanMinHash(m2)
         self.assertTrue(lm1.jaccard(lm2) == 1.0)
-        m2.update(12)
+        m2.update("12")
         lm2 = LeanMinHash(m2)
         self.assertTrue(lm1.jaccard(lm2) == 0.0)
-        m1.update(13)
+        m1.update("13")
         lm1 = LeanMinHash(m1)
         self.assertTrue(lm1.jaccard(lm2) < 1.0)
 
     def test_merge(self):
-        m1 = MinHash(4, 1, hashobj=FakeHash)
-        m2 = MinHash(4, 1, hashobj=FakeHash)
-        m2.update(12)
+        m1 = MinHash(4, 1)
+        m2 = MinHash(4, 1)
+        m2.update("12")
         lm1 = LeanMinHash(m1)
         lm2 = LeanMinHash(m2)
         lm1.merge(lm2)
         self.assertTrue(lm1.jaccard(lm2) == 1.0)
 
     def test_union(self):
-        m1 = MinHash(4, 1, hashobj=FakeHash)
-        m2 = MinHash(4, 1, hashobj=FakeHash)
-        m2.update(12)
+        m1 = MinHash(4, 1)
+        m2 = MinHash(4, 1)
+        m2.update("12")
         lm1 = LeanMinHash(m1)
         lm2 = LeanMinHash(m2)
         u = LeanMinHash.union(lm1, lm2)
         self.assertTrue(u.jaccard(lm2) == 1.0)
 
     def test_bytesize(self):
-        m1 = MinHash(4, 1, hashobj=FakeHash)
+        m1 = MinHash(4, 1)
         lm1 = LeanMinHash(m1)
         self.assertTrue(lm1.bytesize() == (4*4)+4+8)
 
     def test_serialize(self):
-        m1 = MinHash(2, 1, hashobj=FakeHash)
+        m1 = MinHash(2, 1)
         lm1 = LeanMinHash(m1)
         buf = bytearray(lm1.bytesize())
         # Only test for syntax
         lm1.serialize(buf)
 
-        m2 = MinHash(2, 1, hashobj=FakeHash)
+        m2 = MinHash(2, 1)
         lm2 = LeanMinHash(m2)
         size = lm1.bytesize()
         buf = bytearray(size*2)
@@ -98,8 +81,8 @@ class TestLeanMinHash(unittest.TestCase):
         lm2.serialize(buf[size:])
 
     def test_deserialize(self):
-        m1 = MinHash(10, 1, hashobj=FakeHash)
-        m1.update(123)
+        m1 = MinHash(10, 1)
+        m1.update("123")
         lm1 = LeanMinHash(m1)
         buf = bytearray(lm1.bytesize())
         lm1.serialize(buf)
@@ -107,7 +90,6 @@ class TestLeanMinHash(unittest.TestCase):
         # Test if we get back the exact same LeanMinHash objects after
         # deserializing from bytes
         lm1d = LeanMinHash.deserialize(buf)
-        lm1d.hashobj = FakeHash
         self.assertEqual(lm1d.seed, lm1.seed)
         self.assertEqual(len(lm1d.hashvalues), len(lm1.hashvalues))
         self.assertTrue(all(hvd == hv for hv, hvd in zip(lm1.hashvalues,
@@ -115,8 +97,8 @@ class TestLeanMinHash(unittest.TestCase):
 
     def test_deserialize_byteorder(self):
         for byteorder in "@=<>!":
-            m1 = MinHash(10, 1, hashobj=FakeHash)
-            m1.update(123)
+            m1 = MinHash(10, 1)
+            m1.update("123")
             lm1 = LeanMinHash(m1)
             buf = bytearray(lm1.bytesize(byteorder))
             lm1.serialize(buf, byteorder)
@@ -124,16 +106,15 @@ class TestLeanMinHash(unittest.TestCase):
             # Test if we get back the exact same LeanMinHash objects after
             # deserializing from bytes
             lm1d = LeanMinHash.deserialize(buf, byteorder)
-            lm1d.hashobj = FakeHash
             self.assertEqual(lm1d.seed, lm1.seed)
             self.assertEqual(len(lm1d.hashvalues), len(lm1.hashvalues))
             self.assertTrue(all(hvd == hv for hv, hvd in zip(lm1.hashvalues,
                     lm1d.hashvalues)))
 
     def test_pickle(self):
-        m = MinHash(4, 1, hashobj=FakeHash)
-        m.update(123)
-        m.update(45)
+        m = MinHash(4, 1)
+        m.update("123")
+        m.update("45")
         lm = LeanMinHash(m)
 
         p = pickle.loads(pickle.dumps(lm))
@@ -141,16 +122,16 @@ class TestLeanMinHash(unittest.TestCase):
         self.assertTrue(np.array_equal(p.hashvalues, lm.hashvalues))
 
     def test_eq(self):
-        m1 = MinHash(4, 1, hashobj=FakeHash)
-        m2 = MinHash(4, 1, hashobj=FakeHash)
-        m3 = MinHash(4, 2, hashobj=FakeHash)
-        m4 = MinHash(8, 1, hashobj=FakeHash)
-        m5 = MinHash(4, 1, hashobj=FakeHash)
-        m1.update(11)
-        m2.update(12)
-        m3.update(11)
-        m4.update(11)
-        m5.update(11)
+        m1 = MinHash(4, 1)
+        m2 = MinHash(4, 1)
+        m3 = MinHash(4, 2)
+        m4 = MinHash(8, 1)
+        m5 = MinHash(4, 1)
+        m1.update("11")
+        m2.update("12")
+        m3.update("11")
+        m4.update("11")
+        m5.update("11")
         lm1 = LeanMinHash(m1)
         lm2 = LeanMinHash(m2)
         lm3 = LeanMinHash(m3)
@@ -161,36 +142,36 @@ class TestLeanMinHash(unittest.TestCase):
         self.assertNotEqual(lm1, lm4)
         self.assertEqual(lm1, lm5)
 
-        m1.update(12)
-        m2.update(11)
+        m1.update("12")
+        m2.update("11")
         lm1 = LeanMinHash(m1)
         lm2 = LeanMinHash(m2)
         self.assertEqual(lm1, lm2)
 
     def test_count(self):
-        m = MinHash(hashobj=FakeHash)
-        m.update(11)
-        m.update(123)
-        m.update(92)
-        m.update(98)
-        m.update(123218)
-        m.update(32)
+        m = MinHash()
+        m.update("11")
+        m.update("123")
+        m.update("92")
+        m.update("98")
+        m.update("123218")
+        m.update("32")
         lm = LeanMinHash(m)
         c = lm.count()
         self.assertGreaterEqual(c, 0)
 
     def test_hash(self):
-        m = MinHash(hashobj=FakeHash)
-        m.update(11)
-        m.update(123)
-        m.update(92)
-        m.update(98)
-        m.update(123218)
-        m.update(32)
+        m = MinHash()
+        m.update("11")
+        m.update("123")
+        m.update("92")
+        m.update("98")
+        m.update("123218")
+        m.update("32")
         lm1 = LeanMinHash(m)
         lm2 = LeanMinHash(m)
         self.assertEqual(hash(lm1), hash(lm2))
-        m.update(444)
+        m.update("444")
         lm3 = LeanMinHash(m)
         self.assertNotEqual(hash(lm1), hash(lm3))
         d = dict()

--- a/test/minhash_test.py
+++ b/test/minhash_test.py
@@ -1,34 +1,15 @@
 import unittest
 import struct
 import pickle
-from hashlib import sha1
 import numpy as np
 from datasketch import minhash
 from datasketch.b_bit_minhash import bBitMinHash
 
-class FakeHash(object):
-    '''
-    Implmenets the hexdigest required by HyperLogLog.
-    '''
-
-    def __init__(self, h):
-        '''
-        Initialize with an integer
-        '''
-        self.h = h
-
-    def digest(self):
-        '''
-        Return the bytes representation of the integer
-        '''
-        return struct.pack('<Q', self.h)
-
-
 class TestMinHash(unittest.TestCase):
 
     def test_init(self):
-        m1 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m2 = minhash.MinHash(4, 1, hashobj=FakeHash)
+        m1 = minhash.MinHash(4, 1)
+        m2 = minhash.MinHash(4, 1)
         self.assertTrue(np.array_equal(m1.hashvalues, m2.hashvalues))
         self.assertTrue(np.array_equal(m1.permutations, m2.permutations))
 
@@ -37,93 +18,90 @@ class TestMinHash(unittest.TestCase):
         self.assertTrue(m.is_empty())
 
     def test_update(self):
-        m1 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m2 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m1.update(12)
+        m1 = minhash.MinHash(4, 1)
+        m2 = minhash.MinHash(4, 1)
+        m1.update("12")
         for i in range(4):
             self.assertTrue(m1.hashvalues[i] < m2.hashvalues[i])
 
     def test_jaccard(self):
-        m1 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m2 = minhash.MinHash(4, 1, hashobj=FakeHash)
+        m1 = minhash.MinHash(4, 1)
+        m2 = minhash.MinHash(4, 1)
         self.assertTrue(m1.jaccard(m2) == 1.0)
-        m2.update(12)
+        m2.update("12")
         self.assertTrue(m1.jaccard(m2) == 0.0)
-        m1.update(13)
+        m1.update("13")
         self.assertTrue(m1.jaccard(m2) < 1.0)
 
     def test_merge(self):
-        m1 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m2 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m2.update(12)
+        m1 = minhash.MinHash(4, 1)
+        m2 = minhash.MinHash(4, 1)
+        m2.update("12")
         m1.merge(m2)
         self.assertTrue(m1.jaccard(m2) == 1.0)
 
     def test_union(self):
-        m1 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m2 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m2.update(12)
+        m1 = minhash.MinHash(4, 1)
+        m2 = minhash.MinHash(4, 1)
+        m2.update("12")
         u = minhash.MinHash.union(m1, m2)
         self.assertTrue(u.jaccard(m2) == 1.0)
 
     def test_pickle(self):
-        m = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m.update(123)
-        m.update(45)
+        m = minhash.MinHash(4, 1)
+        m.update("123")
+        m.update("45")
         p = pickle.loads(pickle.dumps(m))
         self.assertEqual(p.seed, m.seed)
         self.assertTrue(np.array_equal(p.hashvalues, m.hashvalues))
         self.assertTrue(np.array_equal(p.permutations, m.permutations))
 
     def test_eq(self):
-        m1 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m2 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m3 = minhash.MinHash(4, 2, hashobj=FakeHash)
-        m4 = minhash.MinHash(8, 1, hashobj=FakeHash)
-        m5 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m1.update(11)
-        m2.update(12)
-        m3.update(11)
-        m4.update(11)
-        m5.update(11)
+        m1 = minhash.MinHash(4, 1)
+        m2 = minhash.MinHash(4, 1)
+        m3 = minhash.MinHash(4, 2)
+        m4 = minhash.MinHash(8, 1)
+        m5 = minhash.MinHash(4, 1)
+        m1.update("11")
+        m2.update("12")
+        m3.update("11")
+        m4.update("11")
+        m5.update("11")
         self.assertNotEqual(m1, m2)
         self.assertNotEqual(m1, m3)
         self.assertNotEqual(m1, m4)
         self.assertEqual(m1, m5)
 
-        m1.update(12)
-        m2.update(11)
+        m1.update("12")
+        m2.update("11")
         self.assertEqual(m1, m2)
 
     def test_count(self):
-        m = minhash.MinHash(hashobj=FakeHash)
-        m.update(11)
-        m.update(123)
-        m.update(92)
-        m.update(98)
-        m.update(123218)
-        m.update(32)
+        m = minhash.MinHash()
+        m.update("11")
+        m.update("123")
+        m.update("92")
+        m.update("98")
+        m.update("123218")
+        m.update("32")
         c = m.count()
         self.assertGreaterEqual(c, 0)
 
     def test_byte_tokens(self):
         m = minhash.MinHash(4, 1)
         m.update(b'Hello')
-        self.assertListEqual(
-            m.hashvalues.tolist(),
-            [734825475, 960773806, 359816889, 342714745],
-        )
+        self.assertTrue(all(hv != 0 for hv in m.hashvalues))
 
 class TestbBitMinHash(unittest.TestCase):
 
     def setUp(self):
-        self.m = minhash.MinHash(hashobj=FakeHash)
-        self.m.update(11)
-        self.m.update(123)
-        self.m.update(92)
-        self.m.update(98)
-        self.m.update(123218)
-        self.m.update(32)
+        self.m = minhash.MinHash()
+        self.m.update("11")
+        self.m.update("123")
+        self.m.update("92")
+        self.m.update("98")
+        self.m.update("123218")
+        self.m.update("32")
 
     def test_init(self):
         bm = bBitMinHash(self.m, 1)
@@ -138,16 +116,16 @@ class TestbBitMinHash(unittest.TestCase):
         bm = bBitMinHash(self.m, 32)
 
     def test_eq(self):
-        m1 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m2 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m3 = minhash.MinHash(4, 2, hashobj=FakeHash)
-        m4 = minhash.MinHash(8, 1, hashobj=FakeHash)
-        m5 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m1.update(11)
-        m2.update(12)
-        m3.update(11)
-        m4.update(11)
-        m5.update(11)
+        m1 = minhash.MinHash(4, 1)
+        m2 = minhash.MinHash(4, 1)
+        m3 = minhash.MinHash(4, 2)
+        m4 = minhash.MinHash(8, 1)
+        m5 = minhash.MinHash(4, 1)
+        m1.update("11")
+        m2.update("12")
+        m3.update("11")
+        m4.update("11")
+        m5.update("11")
         m1 = bBitMinHash(m1)
         m2 = bBitMinHash(m2)
         m3 = bBitMinHash(m3)
@@ -159,17 +137,17 @@ class TestbBitMinHash(unittest.TestCase):
         self.assertEqual(m1, m5)
 
     def test_jaccard(self):
-        m1 = minhash.MinHash(4, 1, hashobj=FakeHash)
-        m2 = minhash.MinHash(4, 1, hashobj=FakeHash)
+        m1 = minhash.MinHash(4, 1)
+        m2 = minhash.MinHash(4, 1)
         bm1 = bBitMinHash(m1)
         bm2 = bBitMinHash(m2)
         self.assertTrue(bm1.jaccard(bm2) == 1.0)
 
-        m2.update(12)
+        m2.update("12")
         bm2 = bBitMinHash(m2)
         self.assertTrue(bm1.jaccard(bm2) < 1.0)
 
-        m1.update(13)
+        m1.update("13")
         bm1 = bBitMinHash(m1)
         self.assertTrue(bm1.jaccard(bm2) < 1.0)
 
@@ -179,13 +157,13 @@ class TestbBitMinHash(unittest.TestCase):
 
     def test_pickle(self):
         for num_perm in [1 << i for i in range(4, 10)]:
-            m = minhash.MinHash(num_perm=num_perm, hashobj=FakeHash)
-            m.update(11)
-            m.update(123)
-            m.update(92)
-            m.update(98)
-            m.update(123218)
-            m.update(32)
+            m = minhash.MinHash(num_perm=num_perm)
+            m.update("11")
+            m.update("123")
+            m.update("92")
+            m.update("98")
+            m.update("123218")
+            m.update("32")
             for b in [1, 2, 3, 9, 27, 32]:
                 bm = bBitMinHash(m, b)
                 bm2 = pickle.loads(pickle.dumps(bm))


### PR DESCRIPTION
@aastafiev @ae-foster @vmarkovtsev 

I had to explain to more than a few people why `MinHash` by default use SHA1 hash function, or any of the secure hash functions, because these functions tend to be much slower than non-secure ones like Murmur3. The `hashlib` built-in library only offers secure hash functions, and the `digest` method outputs bytes, which is awkward, as I have to use `struct.unpack` to convert to integer.

```python
# This is how we are doing the hashing right now.
import hashlib, struct
timeit struct.unpack("<I", hashlib.sha1(b"foo").digest()[:4])[0]
# 1 µs ± 27.2 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)

# This is what I am trying to do.
import mmh3
timeit mmh3.hash("foo") & 0xffffffff
# 199 ns ± 6.04 ns per loop (mean ± std. dev. of 7 runs, 10000000 loops each)
```

I am looking at using [`mmh3`](https://pypi.org/project/mmh3/) python library to replace the use of SHA1, and removing `hashobj` parameter all together (`MinHash` and `HyperLogLog`) to make the default fast. Do you think the performance gain is worth it? How much of your code am I going to break?