### PR TITLE
allow passing custom parameters to the constructor of AsyncIOMotorClient

### DIFF
--- a/datasketch/experimental/aio/storage.py
+++ b/datasketch/experimental/aio/storage.py
@@ -138,8 +138,10 @@ if motor is not None and ReturnDocument is not None:
             else:
                 dsn = 'mongodb://{host}:{port}'.format(**self.mongo_param)
 
+            additional_args = self.mongo_param.get('args', {})
+
             self._batch_size = 1000
-            self._mongo_client = motor.motor_asyncio.AsyncIOMotorClient(dsn)
+            self._mongo_client = motor.motor_asyncio.AsyncIOMotorClient(dsn, **additional_args)
             self._collection = self._mongo_client[db_lsh][self._collection_name]
             self._initialized = True
             self._buffer = AsyncMongoBuffer(self._collection, self._batch_size)

--- a/docsrc/lsh.rst
+++ b/docsrc/lsh.rst
@@ -232,6 +232,26 @@ To configure Asynchronous MongoDB storage that will connect to a `replica set <h
 .. code:: python
 
     _storage = {'type': 'aiomongo', 'mongo': {'replica_set': 'rs0', 'replica_set_nodes': 'node1:port1,node2:port2,node3:port3'}}
+
+If you want to pass additional params to the `Mongo client <http://api.mongodb.com/python/current/api/pymongo/mongo_client.html>` constructor, just put them in the ``mongo.args`` object in the storage config (example usage to configure X509 authentication):
+
+.. code:: python
+
+    _storage = {
+        'type': 'aiomongo',
+        'mongo':
+            {
+                ...,
+                'args': {
+                    'ssl': True,
+                    'ssl_ca_certs': 'root-ca.pem',
+                    'ssl_pem_passphrase': 'password',
+                    'ssl_certfile': 'certfile.pem',
+                    'authMechanism': "MONGODB-X509",
+                    'username': "username"
+                }
+            }
+    }
         
 To create index for a large number of MinHashes using asynchronous MinHash LSH.
 


### PR DESCRIPTION
Hi @ekzhu,
I'd like to add an extension to the `AsyncMongoStorage` class -- ability to pass custom params to the constructor of the underlying `pymongo.MongoClient`.