### PR TITLE
Allow equality comparisons against non-datasketch values

### DIFF
--- a/datasketch/b_bit_minhash.py
+++ b/datasketch/b_bit_minhash.py
@@ -46,19 +46,13 @@ class bBitMinHash(object):
     def __eq__(self, other):
         '''
         Check for full equality of two b-bit MinHash objects.
-        '''
-<<<<<<< Updated upstream
-        return self.seed == getattr(other, 'seed', object()) and \
-               self.b == getattr(other, 'b', object()) and \
-               self.r == getattr(other, 'r', object()) and \
-               np.array_equal(self.hashvalues, getattr(other, 'hashvalues', object()))
-=======
+        '''g
         return type(self) is type(other) and \
             self.seed == other.seed and \
             self.b == other.b and \
             self.r == other.r and \
             np.array_equal(self.hashvalues, other.hashvalues)
->>>>>>> Stashed changes
+
 
     def jaccard(self, other):
         '''

--- a/datasketch/b_bit_minhash.py
+++ b/datasketch/b_bit_minhash.py
@@ -47,10 +47,18 @@ class bBitMinHash(object):
         '''
         Check for full equality of two b-bit MinHash objects.
         '''
+<<<<<<< Updated upstream
         return self.seed == getattr(other, 'seed', object()) and \
                self.b == getattr(other, 'b', object()) and \
                self.r == getattr(other, 'r', object()) and \
                np.array_equal(self.hashvalues, getattr(other, 'hashvalues', object()))
+=======
+        return type(self) is type(other) and \
+            self.seed == other.seed and \
+            self.b == other.b and \
+            self.r == other.r and \
+            np.array_equal(self.hashvalues, other.hashvalues)
+>>>>>>> Stashed changes
 
     def jaccard(self, other):
         '''

--- a/datasketch/b_bit_minhash.py
+++ b/datasketch/b_bit_minhash.py
@@ -47,9 +47,10 @@ class bBitMinHash(object):
         '''
         Check for full equality of two b-bit MinHash objects.
         '''
-        return self.seed == other.seed and self.b == other.b and \
-                self.r == other.r and \
-                np.array_equal(self.hashvalues, other.hashvalues)
+        return self.seed == getattr(other, 'seed', object()) and \
+               self.b == getattr(other, 'b', object()) and \
+               self.r == getattr(other, 'r', object()) and \
+               np.array_equal(self.hashvalues, getattr(other, 'hashvalues', object()))
 
     def jaccard(self, other):
         '''

--- a/datasketch/b_bit_minhash.py
+++ b/datasketch/b_bit_minhash.py
@@ -46,7 +46,7 @@ class bBitMinHash(object):
     def __eq__(self, other):
         '''
         Check for full equality of two b-bit MinHash objects.
-        '''g
+        '''
         return type(self) is type(other) and \
             self.seed == other.seed and \
             self.b == other.b and \

--- a/datasketch/hyperloglog.py
+++ b/datasketch/hyperloglog.py
@@ -205,13 +205,10 @@ class HyperLogLog(object):
         Returns:
             bool: True if both have the same internal state.
         '''
-        if self.p != getattr(other, 'p', object()):
-            return False
-        if self.m != getattr(other, 'm', object()):
-            return False
-        if not np.array_equal(self.reg, getattr(other, 'reg', object())):
-            return False
-        return True
+        return type(self) is type(other) and \
+            self.p == other.p and \
+            self.m == other.m and \
+            np.array_equal(self.reg, other.reg)
 
     def _get_rank(self, bits):
         rank = self.max_rank - _bit_length(bits) + 1

--- a/datasketch/hyperloglog.py
+++ b/datasketch/hyperloglog.py
@@ -205,11 +205,11 @@ class HyperLogLog(object):
         Returns:
             bool: True if both have the same internal state.
         '''
-        if self.p != other.p:
+        if self.p != getattr(other, 'p', object()):
             return False
-        if self.m != other.m:
+        if self.m != getattr(other, 'm', object()):
             return False
-        if not np.array_equal(self.reg, other.reg):
+        if not np.array_equal(self.reg, getattr(other, 'reg', object())):
             return False
         return True
 

--- a/datasketch/minhash.py
+++ b/datasketch/minhash.py
@@ -222,8 +222,8 @@ class MinHash(object):
         '''
         :returns: bool -- If their seeds and hash values are both equal then two are equivalent.
         '''
-        return self.seed == other.seed and \
-                np.array_equal(self.hashvalues, other.hashvalues)
+        return self.seed == getattr(other, 'seed', object()) and \
+                np.array_equal(self.hashvalues, getattr(other, 'hashvalues', object()))
 
     @classmethod
     def union(cls, *mhs):

--- a/datasketch/minhash.py
+++ b/datasketch/minhash.py
@@ -222,8 +222,9 @@ class MinHash(object):
         '''
         :returns: bool -- If their seeds and hash values are both equal then two are equivalent.
         '''
-        return self.seed == getattr(other, 'seed', object()) and \
-                np.array_equal(self.hashvalues, getattr(other, 'hashvalues', object()))
+        return type(self) is type(other) and \
+            self.seed == other.seed and \
+            np.array_equal(self.hashvalues, other.hashvalues)
 
     @classmethod
     def union(cls, *mhs):

--- a/datasketch/weighted_minhash.py
+++ b/datasketch/weighted_minhash.py
@@ -74,8 +74,9 @@ class WeightedMinHash(object):
             bool: If their seeds and hash values are both equal then two
             are equivalent.
         '''
-        return self.seed == getattr(other, 'seed', object()) and \
-                np.array_equal(self.hashvalues, getattr(other, 'hashvalues', object()))
+        return type(self) is type(other) and \
+            self.seed == other.seed and \
+            np.array_equal(self.hashvalues, other.hashvalues)
     
 
 class WeightedMinHashGenerator(object):

--- a/datasketch/weighted_minhash.py
+++ b/datasketch/weighted_minhash.py
@@ -75,7 +75,7 @@ class WeightedMinHash(object):
             are equivalent.
         '''
         return self.seed == getattr(other, 'seed', object()) and \
-                np.array_equal(self.hashvalues, other.hashvalues)
+                np.array_equal(self.hashvalues, getattr(other, 'hashvalues', object()))
     
 
 class WeightedMinHashGenerator(object):

--- a/datasketch/weighted_minhash.py
+++ b/datasketch/weighted_minhash.py
@@ -74,7 +74,7 @@ class WeightedMinHash(object):
             bool: If their seeds and hash values are both equal then two
             are equivalent.
         '''
-        return self.seed == other.seed and \
+        return self.seed == getattr(other, 'seed', object()) and \
                 np.array_equal(self.hashvalues, other.hashvalues)
     
 


### PR DESCRIPTION
If I compare datasketch-provided objects against any other type, an error occurs:
```
from datasketch import HyperLogLog
HyperLogLog(p=4) == None
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-2-130aff532e0c> in <module>()
----> 1 HyperLogLog(p=4) == None

/.../eggs/datasketch-1.4.1-py2.7.egg/datasketch/hyperloglog.py in __eq__(self, other)
    206             bool: True if both have the same internal state.
    207         '''
--> 208         if self.p != other.p:
    209             return False
    210         if self.m != other.m:

AttributeError: 'NoneType' object has no attribute 'p'
```

This is troublesome in a few situations where code I don't control chooses to compare e.g. HyperLogLog values against `None` (my use case is to use the serialize/deserialize functions to make a HyperLogLog-typed Django model field, and the model validator unconditionally compares different types).

I think it makes sense to make the __eq__ methods of the `datasketch` types not assume the existence of attributes on what they're being compared against. The `getattr(other, 'field', object())` idiom, while somewhat cryptic, works well here, as the identity comparator (used by `object`) should always fail in a well-behaved __eq__ method.

I've done cursory testing with the HLL changes and minhash changes, and thins seem to work.

Thanks for your consideration (and a great library!).