### PR TITLE
Add warning for when estimate is close to error correction threshold

### DIFF
--- a/datasketch/hyperloglog.py
+++ b/datasketch/hyperloglog.py
@@ -1,7 +1,6 @@
-from __future__ import print_function
 import struct, copy
 import numpy as np
-import sys
+import warnings
 try:
     from .hyperloglog_const import _thresholds, _raw_estimate, _bias
 except ImportError:
@@ -137,9 +136,8 @@ class HyperLogLog(object):
         # Small range correction
         small_range_threshold = (5.0 / 2.0) * self.m
         if abs(e-small_range_threshold)/small_range_threshold < 0.15:
-          print("Warning: estimate is close to error correction threshold\n\
-            Output may not satisfy HyperLogLog accuracy guarantee.",
-            file=sys.stderr)
+          warnings.warn(("Warning: estimate is close to error correction threshold. "
+                        +"Output may not satisfy HyperLogLog accuracy guarantee."))
         if e <= small_range_threshold:
             num_zero = self.m - np.count_nonzero(self.reg)
             return self._linearcounting(num_zero)

--- a/datasketch/hyperloglog.py
+++ b/datasketch/hyperloglog.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import struct, copy
 import numpy as np
 import sys

--- a/datasketch/hyperloglog.py
+++ b/datasketch/hyperloglog.py
@@ -1,5 +1,6 @@
 import struct, copy
 import numpy as np
+import sys
 try:
     from .hyperloglog_const import _thresholds, _raw_estimate, _bias
 except ImportError:
@@ -133,7 +134,12 @@ class HyperLogLog(object):
         # Use HyperLogLog estimation function
         e = self.alpha * float(self.m ** 2) / np.sum(2.0**(-self.reg))
         # Small range correction
-        if e <= (5.0 / 2.0) * self.m:
+        small_range_threshold = (5.0 / 2.0) * self.m
+        if abs(e-small_range_threshold)/small_range_threshold < 0.15:
+          print("Warning: estimate is close to error correction threshold\n\
+            Output may not satisfy HyperLogLog accuracy guarantee.",
+            file=sys.stderr)
+        if e <= small_range_threshold:
             num_zero = self.m - np.count_nonzero(self.reg)
             return self._linearcounting(num_zero)
         # Normal range, no correction


### PR DESCRIPTION
HyperLogLog performs linear counting when the estimate is below a certain threshold. The decision to perform linear counting is based on the estimate, rather than the real count (which is obviously unavailable).

This can lead to cases where the real count is above the threshold but the estimate is below it, triggering linear counting where it is not necessary. The opposite scenario can also occur.

These scenarios lead to a deviation from the accuracy guarantee provided by the authors Flajolet et al. on page 15 of their [paper](http://algo.inria.fr/flajolet/Publications/FlFuGaMe07.pdf) in cases where the real count / estimate is close to the threshold. We used statistical testing to verify that this deviation from accuracy mostly occurs when the estimate is within 15% of the threshold.

Accordingly I have added a warning ~that is displayed to `stderr`~ using the warnings library when the estimate is within 15% of the threshold.