### PR TITLE
Reduce MinHashLSH memory footprint by hashing buckets

### DIFF
--- a/datasketch/lsh.py
+++ b/datasketch/lsh.py
@@ -83,6 +83,9 @@ class MinHashLSH(object):
         prepickle (bool, optional): If True, all keys are pickled to bytes before
             insertion. If None, a default value is chosen based on the
             `storage_config`.
+        hashfunc (function, optional): If a hash function is provided it will be used to
+            compress the index keys to reduce the memory footprint. This could cause a higher
+            false positive rate.
 
     Note:
         `weights` must sum to 1.0, and the format is


### PR DESCRIPTION
I've added the option to pass in a hash function to MinHashLSH. As the cut-off threshold is increased the hash ranges get larger, resulting in larger bucket keys. The hash function can be used to cap the size of these keys, reducing memory footprint. It only makes sense to do this when the hash ranges are larger than 1.

With some naive testing, this change resulted in as much as 90% smaller memory footprint at high thresholds. [Check out my benchmark gist](https://gist.github.com/Sinusoidal36/290041ba98234cf4aaa6d1c0ceed42c0)

What do you think of this approach? Using a 64-bit hash function I think it is quite unlikely this would increase false positives due to collisions. It may even be reasonable to hash the buckets to fewer bits if false positives aren't a concern.