### PR TITLE
Fixes #146; MinhashLSH creates mongo index key.

### DIFF
--- a/datasketch/experimental/aio/storage.py
+++ b/datasketch/experimental/aio/storage.py
@@ -150,6 +150,8 @@ if motor is not None and ReturnDocument is not None:
             self._batch_size = 1000
             self._mongo_client = motor.motor_asyncio.AsyncIOMotorClient(dsn, **additional_args)
             self._collection = self._mongo_client.get_default_database(db_lsh).get_collection(self._collection_name)
+            self._collection.create_index("key", background=True)
+
             self._initialized = True
             self._buffer = AsyncMongoBuffer(self._collection, self._batch_size)
 


### PR DESCRIPTION
Fixes #146, can be verified by querying the db during tests. The index on 'key' is now being created in each bucket and the 'keys' collection too.

```
> show collections
lsh_nbzqpzsztag_bucket_0
lsh_nbzqpzsztag_bucket_1
lsh_nbzqpzsztag_bucket_2
lsh_nbzqpzsztag_bucket_3
lsh_nbzqpzsztag_bucket_4
lsh_nbzqpzsztag_keys
> db.lsh_nbzqpzsztag_bucket_0.getIndexes()
[
	{
		"v" : 2,
		"key" : {
			"_id" : 1
		},
		"name" : "_id_"
	},
	{
		"v" : 2,
		"key" : {
			"key" : 1
		},
		"name" : "key_1"
	}
]
> db.lsh_nbzqpzsztag_keys.getIndexes()
[
	{
		"v" : 2,
		"key" : {
			"_id" : 1
		},
		"name" : "_id_"
	},
	{
		"v" : 2,
		"key" : {
			"key" : 1
		},
		"name" : "key_1"
	}
]
> 

```