### PR TITLE
Add `redis_buffer` configuration.

### DIFF
--- a/datasketch/storage.py
+++ b/datasketch/storage.py
@@ -840,7 +840,8 @@ if redis is not None:
 
                     storage_config={
                         'type': 'redis',
-                        'redis': {'host': 'localhost', 'port': 6379}
+                        'redis': {'host': 'localhost', 'port': 6379},
+                        'redis_buffer': {'transaction': True}
                     }
 
                 one can refer to system environment variables via::
@@ -851,7 +852,8 @@ if redis is not None:
                             'host': {'env': 'REDIS_HOSTNAME',
                                      'default':'localhost'},
                             'port': 6379}
-                        }
+                        },
+                        'redis_buffer': {'transaction': True}
                     }
 
             name (bytes, optional): A prefix to namespace all keys in
@@ -864,9 +866,10 @@ if redis is not None:
             self._buffer_size = 50000
             redis_param = self._parse_config(self.config['redis'])
             self._redis = redis.Redis(**redis_param)
+            redis_buffer_param = self._parse_config(self.config.get('redis_buffer', {}))
             self._buffer = RedisBuffer(self._redis.connection_pool,
                                        self._redis.response_callbacks,
-                                       transaction=True,
+                                       transaction=redis_buffer_param.get('transaction', True),
                                        buffer_size=self._buffer_size)
             if name is None:
                 name = _random_name(11)


### PR DESCRIPTION
Some redis protocol compatible storage (e.g., kvrocks) do not support `MULTI` and `EXEC` command, but they may support pipeline execution. So here provide `transaction` option to the caller to choose if enable transaction.

Currently the redis client will raise a exception when use `lsh.insertion_session`:

```
Traceback (most recent call last):
  File "large_similar_codes_query_perf.py", line 97, in <module>
    session.insert(f"m{i}", m)
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/datasketch-1.5.3-py3.7.egg/datasketch/lsh.py", line 335, in insert
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/datasketch-1.5.3-py3.7.egg/datasketch/lsh.py", line 185, in _insert
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/datasketch-1.5.3-py3.7.egg/datasketch/storage.py", line 966, in insert
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/datasketch-1.5.3-py3.7.egg/datasketch/storage.py", line 972, in _insert
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/redis/client.py", line 3050, in hset
    return self.execute_command('HSET', name, *items)
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/datasketch-1.5.3-py3.7.egg/datasketch/storage.py", line 830, in execute_command
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/redis/client.py", line 4019, in execute
    return execute(conn, stack, raise_on_error)
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/redis/client.py", line 3911, in _execute_transaction
    response = self.parse_response(connection, '_')
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/redis/client.py", line 3978, in parse_response
    self, connection, command_name, **options)
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/redis/client.py", line 915, in parse_response
    response = connection.read_response()
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/redis/connection.py", line 756, in read_response
    raise response
redis.exceptions.ResponseError: unknown command

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "large_similar_codes_query_perf.py", line 97, in <module>
    session.insert(f"m{i}", m)
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/datasketch-1.5.3-py3.7.egg/datasketch/lsh.py", line 317, in __exit__
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/datasketch-1.5.3-py3.7.egg/datasketch/lsh.py", line 322, in close
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/datasketch-1.5.3-py3.7.egg/datasketch/storage.py", line 995, in empty_buffer
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/redis/client.py", line 4019, in execute
    return execute(conn, stack, raise_on_error)
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/redis/client.py", line 3911, in _execute_transaction
    response = self.parse_response(connection, '_')
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/redis/client.py", line 3978, in parse_response
    self, connection, command_name, **options)
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/redis/client.py", line 915, in parse_response
    response = connection.read_response()
  File "/Users/qintianhuan/.pyenv/versions/ma/lib/python3.7/site-packages/redis/connection.py", line 756, in read_response
    raise response
redis.exceptions.ResponseError: unknown command
```

Related code in redis client:

```
    def execute(self, raise_on_error=True):
        "Execute all the commands in the current pipeline"
        stack = self.command_stack
        if not stack and not self.watching:
            return []
        if self.scripts:
            self.load_scripts()
        if self.transaction or self.explicit_transaction:
            execute = self._execute_transaction
        else:
            execute = self._execute_pipeline

...

    def _execute_transaction(self, connection, commands, raise_on_error):
        cmds = chain([(('MULTI', ), {})], commands, [(('EXEC', ), {})])
        all_cmds = connection.pack_commands([args for args, options in cmds
                                             if EMPTY_RESPONSE not in options])
        connection.send_packed_command(all_cmds)
        errors = []
```