### PR TITLE
Add query buffer

### DIFF
--- a/datasketch/lsh.py
+++ b/datasketch/lsh.py
@@ -121,7 +121,7 @@ class MinHashLSH(object):
                     false_positive_weight, false_negative_weight)
 
         self.prepickle = storage_config['type'] == 'redis' if prepickle is None else prepickle
-        
+
         self.hashfunc = hashfunc
         if hashfunc:
             self._H = self._hashed_byteswap
@@ -238,6 +238,9 @@ class MinHashLSH(object):
         Execute and return buffered queries given
         by `add_to_query_buffer`.
 
+        If multiple query MinHash were added to the query buffer,
+        the intersection of the results of all query MinHash will be returned.
+
         Returns:
             `list` of unique keys.
         '''
@@ -294,7 +297,7 @@ class MinHashLSH(object):
 
     def _hashed_byteswap(self, hs):
         return self.hashfunc(bytes(hs.byteswap().data))
-    
+
     def _query_b(self, minhash, b):
         if len(minhash) != self.h:
             raise ValueError("Expecting minhash with length %d, got %d"

--- a/test/test_lsh_cassandra.py
+++ b/test/test_lsh_cassandra.py
@@ -87,6 +87,24 @@ class TestMinHashLSHCassandra(unittest.TestCase):
         m3 = MinHash(18)
         self.assertRaises(ValueError, lsh.query, m3)
 
+    @unittest.skipIf(not DO_TEST_CASSANDRA, "Skipping test_cassandra__query")
+    def test_cassandra__query_buffer(self):
+        lsh = MinHashLSH(threshold=0.5, num_perm=16, storage_config=STORAGE_CONFIG_CASSANDRA)
+        m1 = MinHash(16)
+        m1.update("a".encode("utf8"))
+        m2 = MinHash(16)
+        m2.update("b".encode("utf8"))
+        lsh.insert("a", m1)
+        lsh.insert("b", m2)
+        lsh.add_to_query_buffer(m1)
+        result = lsh.collect_query_buffer()
+        self.assertTrue("a" in result)
+        lsh.add_to_query_buffer(m2)
+        result = lsh.collect_query_buffer()
+        self.assertTrue("b" in result)
+        m3 = MinHash(18)
+        self.assertRaises(ValueError, lsh.add_to_query_buffer, m3)
+
     @unittest.skipIf(not DO_TEST_CASSANDRA, "Skipping test_cassandra__remove")
     def test_cassandra__remove(self):
         lsh = MinHashLSH(threshold=0.5, num_perm=16, storage_config=STORAGE_CONFIG_CASSANDRA)


### PR DESCRIPTION
Inserting a new `MinHash` into a `MinHashLSH` with the cassandra backend gets a great performance boost from using an insertion session together with `shared_buffer` activated because then, the insert queries into all hash tables are done concurrently. Unfortunately, I did not find an equivalently performant way for querying a `MinHash`.

This PR adds a way to also make use of a shared buffer with the cassandra backend when querying data. The procedure is split into two parts: `add_to_query_buffer` and `collect_query_buffer`: Calling them in sequence should be equivalent to calling `query` but alot faster:

```python
lsh.add_to_query_buffer(min_hash)
buffered = lsh.collect_query_buffer()
direct = lsh.query(min_hash)
assert set(buffered) == set(direct)
```

Splitting the function into two parts allows to also add more queries from other lshs to the buffer before executing it.

Also added a dummy implementation for all other storage backends and unit tests.
