### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setup(
     description='Probabilistic data structures for processing and searching very large datasets',
     long_description=long_description,
     url='https://ekzhu.github.io/datasketch',
+    project_urls={
+        'Source': 'https://github.com/ekzhu/datasketch',
+    },
     author='ekzhu',
     author_email='ekzhu@cs.toronto.edu',
     license='MIT',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help automation tool find the source code for Requests.

Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)