### PR TITLE
Fix name construction for all values of b

### DIFF
--- a/datasketch/storage.py
+++ b/datasketch/storage.py
@@ -388,7 +388,7 @@ if cassandra is not None:
             # only one Cassandra table for both table types (so we can keep one single storage) and
             # we specify different encoders/decoders based on the table type.
             if b'bucket' in name:
-                basename, _, ret = name.split(b'_')
+                basename, _, ret = name.split(b'_', 2)
                 name = basename + b'_bucket_' + binascii.hexlify(ret)
                 self._key_decoder = lambda x: x
                 self._key_encoder = lambda x: x

--- a/test/test_lsh.py
+++ b/test/test_lsh.py
@@ -39,6 +39,16 @@ class TestMinHashLSH(unittest.TestCase):
             lsh.insert("m", m)
             sizes = [len(H) for ht in lsh.hashtables for H in ht]
             self.assertTrue(all(sizes[0] == s for s in sizes))
+    
+    def test_unpacking(self):
+        for b in range(1, 1024 + 1):
+            lsh = MinHashLSH(num_perm=b * 4, params=(b, 4))
+            m = MinHash(num_perm=b * 4)
+            m.update("abcdefg".encode("utf8"))
+            m.update("1234567".encode("utf8"))
+            lsh.insert("m", m)
+            sizes = [len(H) for ht in lsh.hashtables for H in ht]
+            self.assertTrue(all(sizes[0] == s for s in sizes))
 
     def test_insert(self):
         lsh = MinHashLSH(threshold=0.5, num_perm=16)


### PR DESCRIPTION
https://github.com/ekzhu/datasketch/blob/master/datasketch/lsh.py#L118

In lsh.py when we are iterating over values of b and b reaches 95 the packed value of 95 contains an underscore

```python
In [7]: for i in range(100):
   ...:     print(i, struct.pack('>H', i))
   ...: 
0 b'\x00\x00'
1 b'\x00\x01'
2 b'\x00\x02'
3 b'\x00\x03'
4 b'\x00\x04'
5 b'\x00\x05'
6 b'\x00\x06'
7 b'\x00\x07'
8 b'\x00\x08'
9 b'\x00\t'
10 b'\x00\n'
11 b'\x00\x0b'
12 b'\x00\x0c'
13 b'\x00\r'
14 b'\x00\x0e'
15 b'\x00\x0f'
16 b'\x00\x10'
17 b'\x00\x11'
18 b'\x00\x12'
19 b'\x00\x13'
20 b'\x00\x14'
.....
.....
95 b'\x00_' # This is an issue for unpacking after split
96 b'\x00`'
97 b'\x00a'
98 b'\x00b'
99 b'\x00c'
```

this completely breaks this naming here due to split and you get unpacking error.

```python

In [32]: name = b''.join([_random_name(11), b'_bucket_', struct.pack('>H', 95)])

In [33]: basename, _, ret = name.split(b'_')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Input In [33], in <cell line: 1>()
----> 1 basename, _, ret = name.split(b'_')

ValueError: too many values to unpack (expected 3)
```

while the fix

```python
In [41]: name.split(b'_', 2)
Out[41]: [b'kulxcuapyqa', b'bucket', b'\x00_']
```

Gives us expected behaviour