### PR TITLE
Update MinHashLSH.query docstring detailing proximal nature of results

### DIFF
--- a/datasketch/lsh.py
+++ b/datasketch/lsh.py
@@ -175,8 +175,12 @@ class MinHashLSH(object):
     def query(self, minhash):
         '''
         Giving the MinHash of the query set, retrieve
-        the keys that references sets with Jaccard
-        similarities greater than the threshold.
+        the keys that reference sets with Jaccard
+        similarities likely greater than the threshold.
+
+        Results are based on minhash segment collision
+        and are thus approximate. For exact results,
+        filter again with `minhash.jaccard`.
 
         Args:
             minhash (datasketch.MinHash): The MinHash of the query set.

--- a/datasketch/lsh.py
+++ b/datasketch/lsh.py
@@ -179,8 +179,9 @@ class MinHashLSH(object):
         similarities likely greater than the threshold.
 
         Results are based on minhash segment collision
-        and are thus approximate. For exact results,
-        filter again with `minhash.jaccard`.
+        and are thus approximate. For more accurate results,
+        filter again with `minhash.jaccard`. For exact results,
+        filter by computing Jaccard similarity using original sets.
 
         Args:
             minhash (datasketch.MinHash): The MinHash of the query set.


### PR DESCRIPTION
Fixes incorrect docstring and should hopefully eliminate some usage confusion