### PR TITLE
Update lshforest.py

### DIFF
--- a/datasketch/lshforest.py
+++ b/datasketch/lshforest.py
@@ -112,15 +112,15 @@ class MinHashLSHForest(object):
             raise ValueError("k must be positive")
         if len(minhash) < self.k*self.l:
             raise ValueError("The num_perm of MinHash out of range")
-        results = set()
+        results = {}
         r = self.k
         while r > 0:
             for key in self._query(minhash, r, self.l):
-                results.add(key)
+                results[key]=''
                 if len(results) >= k:
-                    return list(results)
+                    return list(results.keys())
             r -= 1
-        return list(results)
+        return list(results.keys())
 
     def _binary_search(self, n, func):
         '''


### PR DESCRIPTION
In the "query" function, I changed the "results" variable type from **_set_** into **_dictionary_**. Since the order is important, set data structure does not preserve the order unlike dictionary in python.

The use is only for the dictionary keys which is eventually returned as a list.

Example: 

data_sets = [
    [1, 2, 3, 4, 5],
    [4, 5, 6, 7, 8],
    [2, 3, 5, 6, 7]
]

query_set = [1, 2, 3, 4, 5, 6]

The actual Jaccard between query_set and each of the data sets as follows:
0) 0.8333333333333334
1) 0.375
2) 0.5714285714285714

Therefore the returned order based on the actual Jaccard score is **[0,2,1]**
However, the original implementation with **_set_** data structure returns [0,1,2], although the search function is correct. 

After my enhancement, the returned list is [0,2,1] (more accurate than before).

This will significantly improve the implementation of LSH-Forest.
