### PR TITLE
simplify reshapes

### DIFF
--- a/datasketch/lsh.py
+++ b/datasketch/lsh.py
@@ -105,6 +105,8 @@ class MinHashLSH(object):
             false_positive_weight, false_negative_weight = weights
             self.b, self.r = _optimal_param(threshold, num_perm,
                     false_positive_weight, false_negative_weight)
+        if self.b < 2:
+            raise ValueError("The number of bands are too small (b < 2)")
 
         self.prepickle = storage_config['type'] == 'redis' if prepickle is None else prepickle
 

--- a/datasketch/minhash.py
+++ b/datasketch/minhash.py
@@ -155,9 +155,9 @@ class MinHash(object):
                 minhash = Minhash()
                 minhash.update_batch([s.encode('utf-8') for s in ["token1", "token2"]])
         '''
-        hv = np.array([self.hashfunc(_b) for _b in b], dtype=np.uint64)
+        hv = np.array([self.hashfunc(_b) for _b in b], dtype=np.uint64,ndmin=2).T
         a, b = self.permutations
-        phv = np.bitwise_and(((hv * np.tile(a, (len(hv), 1)).T).T + b) % _mersenne_prime, _max_hash)
+        phv = np.bitwise_and(((hv * np.tile(a, (len(hv), 1))) + b) % _mersenne_prime, _max_hash)
         self.hashvalues = np.vstack([phv, self.hashvalues]).min(axis=0)
 
     def jaccard(self, other):

--- a/datasketch/minhash.py
+++ b/datasketch/minhash.py
@@ -157,7 +157,7 @@ class MinHash(object):
         '''
         hv = np.array([self.hashfunc(_b) for _b in b], dtype=np.uint64,ndmin=2).T
         a, b = self.permutations
-        phv = np.bitwise_and(((hv * np.tile(a, (len(hv), 1))) + b) % _mersenne_prime, _max_hash)
+        phv = (hv * a + b) % _mersenne_prime & _max_hash
         self.hashvalues = np.vstack([phv, self.hashvalues]).min(axis=0)
 
     def jaccard(self, other):

--- a/test/test_lsh.py
+++ b/test/test_lsh.py
@@ -41,7 +41,7 @@ class TestMinHashLSH(unittest.TestCase):
             self.assertTrue(all(sizes[0] == s for s in sizes))
     
     def test_unpacking(self):
-        for b in range(1, 1024 + 1):
+        for b in range(2, 1024 + 1):
             lsh = MinHashLSH(num_perm=b * 4, params=(b, 4))
             m = MinHash(num_perm=b * 4)
             m.update("abcdefg".encode("utf8"))


### PR DESCRIPTION
This arguably makes the code easier to read, and reduces one transpose `.T` operation.

the `ndmin=2` is required for the transpose to be valid.