### PR TITLE
Retrieve MinHash from LSHForest

### DIFF
--- a/datasketch/lshforest.py
+++ b/datasketch/lshforest.py
@@ -143,7 +143,7 @@ class MinHashLSHForest(object):
         """
         byteslist = self.keys.get(key, None)
         if byteslist is None:
-            raise KeyError("The provided key does not exist in the LSHForest: {key}")
+            raise KeyError(f"The provided key does not exist in the LSHForest: {key}")
         hashvalues = np.array([], dtype=np.uint64)
         for item in byteslist:
             # unswap the bytes, as their representation is flipped during storage

--- a/datasketch/lshforest.py
+++ b/datasketch/lshforest.py
@@ -144,11 +144,13 @@ class MinHashLSHForest(object):
         byteslist = self.keys.get(key, None)
         if byteslist is None:
             raise KeyError(f"The provided key does not exist in the LSHForest: {key}")
-        hashvalues = np.array([], dtype=np.uint64)
-        for item in byteslist:
+        hashvalue_byte_size = len(byteslist[0])//8
+        hashvalues = np.empty(len(byteslist)*hashvalue_byte_size, dtype=np.uint64)
+        for index, item in enumerate(byteslist):
             # unswap the bytes, as their representation is flipped during storage
             hv_segment = np.frombuffer(item, dtype=np.uint64).byteswap()
-            hashvalues = np.append(hashvalues, hv_segment)
+            curr_index = index*hashvalue_byte_size
+            hashvalues[curr_index:curr_index+hashvalue_byte_size] = hv_segment
         return hashvalues
 
     def _binary_search(self, n, func):

--- a/datasketch/lshforest.py
+++ b/datasketch/lshforest.py
@@ -131,8 +131,10 @@ class MinHashLSHForest(object):
 
     def get_minhash_from_key(self, key: Hashable) -> MinHash:
         """
-        Returns the MinHash value that corresponds to the given key in the LSHForest, if it exists. This is useful for when we want to manually check the Jaccard Similarity for the top-k results from a query.
-        
+        Returns the MinHash value that corresponds to the given key in the LSHForest,
+        if it exists. This is useful for when we want to manually check the 
+        Jaccard Similarity for the top-k results from a query.
+
         Args:
             key (Hashable): The key whose MinHash we want to retrieve.
 

--- a/datasketch/lshforest.py
+++ b/datasketch/lshforest.py
@@ -129,17 +129,17 @@ class MinHashLSHForest(object):
             r -= 1
         return list(results)
 
-    def get_minhash_from_key(self, key: Hashable) -> MinHash:
+    def get_minhash_hashvalues(self, key: Hashable) -> np.ndarray:
         """
-        Returns the MinHash value that corresponds to the given key in the LSHForest,
-        if it exists. This is useful for when we want to manually check the 
-        Jaccard Similarity for the top-k results from a query.
+        Returns the hashvalues from the MinHash object that corresponds to the given key in the LSHForest,
+        if it exists. This is useful for when we want to reconstruct the original MinHash
+        object to manually check the Jaccard Similarity for the top-k results from a query.
 
         Args:
-            key (Hashable): The key whose MinHash we want to retrieve.
+            key (Hashable): The key whose MinHash hashvalues we want to retrieve.
 
         Returns:
-            MinHash: The corresponding MinHash value for the provided key.
+            hashvalues: The hashvalues for the MinHash object corresponding to the given key.
         """
         byteslist = self.keys.get(key, None)
         if byteslist is None:
@@ -149,8 +149,7 @@ class MinHashLSHForest(object):
             # unswap the bytes, as their representation is flipped during storage
             hv_segment = np.frombuffer(item, dtype=np.uint64).byteswap()
             hashvalues = np.append(hashvalues, hv_segment)
-        minhash = MinHash(hashvalues=hashvalues)
-        return minhash
+        return hashvalues
 
     def _binary_search(self, n, func):
         """

--- a/datasketch/lshforest.py
+++ b/datasketch/lshforest.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from typing import Hashable, List
+import numpy as np
 
 from datasketch.minhash import MinHash
 
@@ -127,6 +128,27 @@ class MinHashLSHForest(object):
                     return list(results)
             r -= 1
         return list(results)
+
+    def get_minhash_from_key(self, key: Hashable) -> MinHash:
+        """
+        Returns the MinHash value that corresponds to the given key in the LSHForest, if it exists. This is useful for when we want to manually check the Jaccard Similarity for the top-k results from a query.
+        
+        Args:
+            key (Hashable): The key whose MinHash we want to retrieve.
+
+        Returns:
+            MinHash: The corresponding MinHash value for the provided key.
+        """
+        byteslist = self.keys.get(key, None)
+        if byteslist is None:
+            raise KeyError("The provided key does not exist in the LSHForest: {key}")
+        hashvalues = np.array([], dtype=np.uint64)
+        for item in byteslist:
+            # unswap the bytes, as their representation is flipped during storage
+            hv_segment = np.frombuffer(item, dtype=np.uint64).byteswap()
+            hashvalues = np.append(hashvalues, hv_segment)
+        minhash = MinHash(hashvalues=hashvalues)
+        return minhash
 
     def _binary_search(self, n, func):
         """

--- a/test/test_lshforest.py
+++ b/test/test_lshforest.py
@@ -68,7 +68,6 @@ class TestMinHashLSHForest(unittest.TestCase):
             minhash_ori = data[key]
             minhash_retrieved = forest.get_minhash_from_key(key)
             self.assertEqual(minhash_retrieved.jaccard(minhash_ori), 1.0)
-            
 
     def test_pickle(self):
         forest, _ = self._setup()

--- a/test/test_lshforest.py
+++ b/test/test_lshforest.py
@@ -68,7 +68,11 @@ class TestMinHashLSHForest(unittest.TestCase):
             minhash_ori = data[key]
             hashvalues = forest.get_minhash_hashvalues(key)
             minhash_retrieved = MinHash(hashvalues=hashvalues)
+            retrieved_hashvalues = minhash_retrieved.hashvalues
+            self.assertEqual(len(hashvalues), len(retrieved_hashvalues))
             self.assertEqual(minhash_retrieved.jaccard(minhash_ori), 1.0)
+            for i in range(len(retrieved_hashvalues)):
+                self.assertEqual(hashvalues[i], retrieved_hashvalues[i])
 
     def test_pickle(self):
         forest, _ = self._setup()

--- a/test/test_lshforest.py
+++ b/test/test_lshforest.py
@@ -62,11 +62,11 @@ class TestMinHashLSHForest(unittest.TestCase):
             results = forest.query(data[key], 10)
             self.assertIn(key, results)
 
-    def get_minhash_hashvalues(self):
+    def test_get_minhash_hashvalues(self):
         forest, data = self._setup()
         for key in data:
             minhash_ori = data[key]
-            hashvalues = forest.get_minhash_from_key(key)
+            hashvalues = forest.get_minhash_hashvalues(key)
             minhash_retrieved = MinHash(hashvalues=hashvalues)
             self.assertEqual(minhash_retrieved.jaccard(minhash_ori), 1.0)
 

--- a/test/test_lshforest.py
+++ b/test/test_lshforest.py
@@ -62,11 +62,12 @@ class TestMinHashLSHForest(unittest.TestCase):
             results = forest.query(data[key], 10)
             self.assertIn(key, results)
 
-    def test_get_minhash(self):
+    def get_minhash_hashvalues(self):
         forest, data = self._setup()
         for key in data:
             minhash_ori = data[key]
-            minhash_retrieved = forest.get_minhash_from_key(key)
+            hashvalues = forest.get_minhash_from_key(key)
+            minhash_retrieved = MinHash(hashvalues=hashvalues)
             self.assertEqual(minhash_retrieved.jaccard(minhash_ori), 1.0)
 
     def test_pickle(self):

--- a/test/test_lshforest.py
+++ b/test/test_lshforest.py
@@ -62,6 +62,14 @@ class TestMinHashLSHForest(unittest.TestCase):
             results = forest.query(data[key], 10)
             self.assertIn(key, results)
 
+    def test_get_minhash(self):
+        forest, data = self._setup()
+        for key in data:
+            minhash_ori = data[key]
+            minhash_retrieved = forest.get_minhash_from_key(key)
+            self.assertEqual(minhash_retrieved.jaccard(minhash_ori), 1.0)
+            
+
     def test_pickle(self):
         forest, _ = self._setup()
         forest2 = pickle.loads(pickle.dumps(forest))


### PR DESCRIPTION
Adds the ability to retrieve a `MinHash` from the `MinHashLSHForest` object, which is useful in workflows where we wish to manually threshold the results of a top-k query from the LSHForest.

```
lsh = MinHashLSHForest(...)
mh = lsh.get_minhash_from_key(mykey)

# now use mh.jaccard() ...
```

Please let me know if I should change any naming/formatting, I tried my best to keep in step with what was already present.

@ekzhu 

closes #233 