### PR TITLE
fix(dependabot): drop versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-    versioning-strategy: "widen"
     labels:
       - "dependencies"
     pull-request-branch-name:


### PR DESCRIPTION
## What does this PR do?

Drops the versioning strategy for Dependabot.

It seemed to be accepted, but it still appears to fail in master: [https://github.com/ekzhu/datasketch/runs/54435048125](https://github.com/ekzhu/datasketch/runs/54435048125)

So, let's drop it for simplicity.

ref: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy--