### PR TITLE
Fix buffered MinHashLSH query aggregation across storage backends

### DIFF
--- a/datasketch/lsh.py
+++ b/datasketch/lsh.py
@@ -471,7 +471,7 @@ class MinHashLSH:
         # union candidates across bands for each query, then intersect across the
         # buffered queries to match repeated calls to `query()`.
         per_query_result_sets = [
-            set().union(*(set(result_list) for result_list in query_result_lists))
+            set().union(*query_result_lists)
             for query_result_lists in zip(*collected_result_lists)
         ]
         if not per_query_result_sets:

--- a/datasketch/lsh.py
+++ b/datasketch/lsh.py
@@ -463,16 +463,24 @@ class MinHashLSH:
             list: a list of unique keys.
 
         """
-        collected_result_sets = [
-            set(collected_result_lists)
-            for hashtable in self.hashtables
-            for collected_result_lists in hashtable.collect_select_buffer()
-        ]
-        if not collected_result_sets:
+        collected_result_lists = [hashtable.collect_select_buffer() for hashtable in self.hashtables]
+        if not any(collected_result_lists):
             return []
+
+        # Each buffered query contributes one result list per hashtable. We first
+        # union candidates across bands for each query, then intersect across the
+        # buffered queries to match repeated calls to `query()`.
+        per_query_result_sets = [
+            set().union(*(set(result_list) for result_list in query_result_lists))
+            for query_result_lists in zip(*collected_result_lists)
+        ]
+        if not per_query_result_sets:
+            return []
+
+        candidates = set.intersection(*per_query_result_sets)
         if self.prepickle:
-            return [pickle.loads(key) for key in set.intersection(*collected_result_sets)]
-        return list(set.intersection(*collected_result_sets))
+            return [pickle.loads(key) for key in candidates]
+        return list(candidates)
 
     def __contains__(self, key: Hashable) -> bool:
         """Args:

--- a/datasketch/lshensemble.py
+++ b/datasketch/lshensemble.py
@@ -204,7 +204,7 @@ class MinHashLSHEnsemble:
         if not self.is_empty():
             raise ValueError("Cannot call index again on a non-empty index")
         if not isinstance(entries, list):
-            queue = deque([])
+            queue = deque()
             for key, minhash, size in entries:
                 if size <= 0:
                     raise ValueError("Set size must be positive")

--- a/datasketch/lshforest.py
+++ b/datasketch/lshforest.py
@@ -9,8 +9,8 @@ from datasketch.minhash import MinHash
 class MinHashLSHForest:
     """The LSH Forest for MinHash. It supports top-k query in Jaccard
     similarity.
-    Instead of using prefix trees as the `original paper
-    <http://ilpubs.stanford.edu:8090/678/1/2005-14.pdf>`_,
+    Instead of using prefix trees as described in the original LSH Forest
+    paper by Bawa et al. (WWW 2005),
     I use a sorted array to store the hash values in every
     hash table.
 
@@ -37,7 +37,8 @@ class MinHashLSHForest:
         # Maximum depth of the prefix tree
         self.k = int(num_perm / l)
         self.hashtables = [defaultdict(list) for _ in range(self.l)]
-        self.hashranges = [(i * self.k, (i + 1) * self.k) for i in range(self.l)]
+        self.hashranges = [(i * self.k, (i + 1) * self.k)
+                           for i in range(self.l)]
         self.keys = dict()
         # This is the sorted array implementation for the prefix trees
         self.sorted_hashtables = [[] for _ in range(self.l)]
@@ -59,7 +60,8 @@ class MinHashLSHForest:
             raise ValueError("The num_perm of MinHash out of range")
         if key in self.keys:
             raise ValueError("The given key has already been added")
-        self.keys[key] = [self._H(minhash.hashvalues[start:end]) for start, end in self.hashranges]
+        self.keys[key] = [self._H(minhash.hashvalues[start:end])
+                          for start, end in self.hashranges]
         for H, hashtable in zip(self.keys[key], self.hashtables):
             hashtable[H].append(key)
 
@@ -73,11 +75,13 @@ class MinHashLSHForest:
         if r > self.k or r <= 0 or b > self.l or b <= 0:
             raise ValueError("parameter outside range")
         # Generate prefixes of concatenated hash values
-        hps = [self._H(minhash.hashvalues[start : start + r]) for start, _ in self.hashranges]
+        hps = [self._H(minhash.hashvalues[start: start + r])
+               for start, _ in self.hashranges]
         # Set the prefix length for look-ups in the sorted hash values list
         prefix_size = len(hps[0])
         for ht, hp, hashtable in zip(self.sorted_hashtables, hps, self.hashtables):
-            i = self._binary_search(len(ht), lambda x, ht=ht, hp=hp: ht[x][:prefix_size] >= hp)
+            i = self._binary_search(
+                len(ht), lambda x, ht=ht, hp=hp: ht[x][:prefix_size] >= hp)
             if i < len(ht) and ht[i][:prefix_size] == hp:
                 j = i
                 while j < len(ht) and ht[j][:prefix_size] == hp:
@@ -137,14 +141,17 @@ class MinHashLSHForest:
         """
         byteslist = self.keys.get(key, None)
         if byteslist is None:
-            raise KeyError(f"The provided key does not exist in the LSHForest: {key}")
+            raise KeyError(
+                f"The provided key does not exist in the LSHForest: {key}")
         hashvalue_byte_size = len(byteslist[0]) // 8
-        hashvalues = np.empty(len(byteslist) * hashvalue_byte_size, dtype=np.uint64)
+        hashvalues = np.empty(
+            len(byteslist) * hashvalue_byte_size, dtype=np.uint64)
         for index, item in enumerate(byteslist):
             # unswap the bytes, as their representation is flipped during storage
             hv_segment = np.frombuffer(item, dtype=np.uint64).byteswap()
             curr_index = index * hashvalue_byte_size
-            hashvalues[curr_index : curr_index + hashvalue_byte_size] = hv_segment
+            hashvalues[curr_index: curr_index +
+                       hashvalue_byte_size] = hv_segment
         return hashvalues
 
     def _binary_search(self, n, func):

--- a/datasketch/storage.py
+++ b/datasketch/storage.py
@@ -603,12 +603,14 @@ if cassandra is not None:
             del self._select_statements_and_parameters_with_decoders[:]
             statements_and_parameters, decoders = zip(*buffer)
 
-            ret = collections.defaultdict(list)
             query_results = self._select(statements_and_parameters)
-            for rows, (key_decoder, val_decoder) in zip(query_results, decoders):
+            ret = []
+            for rows, (_key_decoder, val_decoder) in zip(query_results, decoders):
+                values = []
                 for row in rows:
-                    ret[key_decoder(row.key)].append((val_decoder(row.value), row.ts))
-            return [[x[0] for x in sorted(v, key=operator.itemgetter(1))] for v in ret.values()]
+                    values.append((val_decoder(row.value), row.ts))
+                ret.append([x[0] for x in sorted(values, key=operator.itemgetter(1))])
+            return ret
 
         def select(self, keys):
             """Select all values for the given keys.

--- a/docs/lshforest.rst
+++ b/docs/lshforest.rst
@@ -5,7 +5,7 @@ MinHash LSH Forest
 
 :ref:`minhash_lsh` is useful for radius (or threshold) queries. However,
 **top-k** queries are often more useful in some cases. `LSH
-Forest <http://ilpubs.stanford.edu:8090/678/1/2005-14.pdf>`__ by Bawa et
+Forest <https://dblp.org/rec/conf/www/BawaCG05>`__ by Bawa et
 al. is a general LSH data structure that makes top-k query possible for
 many different types of LSH indexes, which include MinHash LSH. I
 implemented the MinHash LSH Forest, which takes a :ref:`minhash` data sketch of
@@ -70,7 +70,7 @@ for details.
    :alt: MinHashLSHForest Benchmark
 
 (Optional) If you have read the LSH Forest
-`paper <http://ilpubs.stanford.edu:8090/678/1/2005-14.pdf>`__, and
+`paper <https://dblp.org/rec/conf/www/BawaCG05>`__, and
 understand the data structure, you may want to customize another
 parameter for :class:`datasketch.MinHashLSHForest` -- ``l``, the number of prefix trees
 (or "LSH Trees" as in the paper) in the LSH Forest index. Different from

--- a/docs/lshforest.rst
+++ b/docs/lshforest.rst
@@ -4,9 +4,8 @@ MinHash LSH Forest
 ==================
 
 :ref:`minhash_lsh` is useful for radius (or threshold) queries. However,
-**top-k** queries are often more useful in some cases. `LSH
-Forest <https://dblp.org/rec/conf/www/BawaCG05>`__ by Bawa et
-al. is a general LSH data structure that makes top-k query possible for
+**top-k** queries are often more useful in some cases. LSH
+Forest by Bawa et al. (WWW 2005) is a general LSH data structure that makes top-k query possible for
 many different types of LSH indexes, which include MinHash LSH. I
 implemented the MinHash LSH Forest, which takes a :ref:`minhash` data sketch of
 the query set, and returns the top-k matching sets that have the 
@@ -69,9 +68,8 @@ for details.
 .. figure:: /_static/lshforest_benchmark.png
    :alt: MinHashLSHForest Benchmark
 
-(Optional) If you have read the LSH Forest
-`paper <https://dblp.org/rec/conf/www/BawaCG05>`__, and
-understand the data structure, you may want to customize another
+(Optional) If you have read the original LSH Forest paper by Bawa et al.
+(WWW 2005) and understand the data structure, you may want to customize another
 parameter for :class:`datasketch.MinHashLSHForest` -- ``l``, the number of prefix trees
 (or "LSH Trees" as in the paper) in the LSH Forest index. Different from
 the paper, this implementation fixes the number of LSH functions, in

--- a/test/test_lsh.py
+++ b/test/test_lsh.py
@@ -124,6 +124,24 @@ class TestMinHashLSH(unittest.TestCase):
         self.assertEqual(buffered_result, direct_result)
         self.assertEqual(buffered_result, {0, 1})
 
+    def test_query_buffer_with_prepickle(self):
+        lsh = MinHashLSH(threshold=0.5, num_perm=32, prepickle=True)
+        docs = []
+        for tokens in ([b"a", b"b", b"c"], [b"a", b"b", b"d"], [b"x", b"y", b"z"]):
+            minhash = MinHash(num_perm=32)
+            for token in tokens:
+                minhash.update(token)
+            docs.append(minhash)
+        for key, minhash in enumerate(docs):
+            lsh.insert(key, minhash)
+
+        lsh.add_to_query_buffer(docs[0])
+        buffered_result = set(lsh.collect_query_buffer())
+        direct_result = set(lsh.query(docs[0]))
+
+        self.assertEqual(buffered_result, direct_result)
+        self.assertEqual(buffered_result, {0, 1})
+
     def test_remove(self):
         lsh = MinHashLSH(threshold=0.5, num_perm=16)
         m1 = MinHash(16)

--- a/test/test_lsh.py
+++ b/test/test_lsh.py
@@ -124,24 +124,6 @@ class TestMinHashLSH(unittest.TestCase):
         self.assertEqual(buffered_result, direct_result)
         self.assertEqual(buffered_result, {0, 1})
 
-    def test_query_buffer_with_prepickle(self):
-        lsh = MinHashLSH(threshold=0.5, num_perm=32, prepickle=True)
-        docs = []
-        for tokens in ([b"a", b"b", b"c"], [b"a", b"b", b"d"], [b"x", b"y", b"z"]):
-            minhash = MinHash(num_perm=32)
-            for token in tokens:
-                minhash.update(token)
-            docs.append(minhash)
-        for key, minhash in enumerate(docs):
-            lsh.insert(key, minhash)
-
-        lsh.add_to_query_buffer(docs[0])
-        buffered_result = set(lsh.collect_query_buffer())
-        direct_result = set(lsh.query(docs[0]))
-
-        self.assertEqual(buffered_result, direct_result)
-        self.assertEqual(buffered_result, {0, 1})
-
     def test_remove(self):
         lsh = MinHashLSH(threshold=0.5, num_perm=16)
         m1 = MinHash(16)

--- a/test/test_lsh.py
+++ b/test/test_lsh.py
@@ -106,6 +106,24 @@ class TestMinHashLSH(unittest.TestCase):
         m3 = MinHash(18)
         self.assertRaises(ValueError, lsh.add_to_query_buffer, m3)
 
+    def test_query_buffer_matches_query_candidates(self):
+        lsh = MinHashLSH(threshold=0.5, num_perm=32)
+        docs = []
+        for tokens in ([b"a", b"b", b"c"], [b"a", b"b", b"d"], [b"x", b"y", b"z"]):
+            minhash = MinHash(num_perm=32)
+            for token in tokens:
+                minhash.update(token)
+            docs.append(minhash)
+        for key, minhash in enumerate(docs):
+            lsh.insert(key, minhash)
+
+        lsh.add_to_query_buffer(docs[0])
+        buffered_result = set(lsh.collect_query_buffer())
+        direct_result = set(lsh.query(docs[0]))
+
+        self.assertEqual(buffered_result, direct_result)
+        self.assertEqual(buffered_result, {0, 1})
+
     def test_remove(self):
         lsh = MinHashLSH(threshold=0.5, num_perm=16)
         m1 = MinHash(16)


### PR DESCRIPTION
## Summary                                                                                                                                   
  Fix `MinHashLSH.collect_query_buffer()` so buffered queries aggregate candidates the same way as repeated calls to `query()`, including when 
  using the Cassandra storage backend.                                                                                                         
                                                                                                                                               
  ## Problem                                                                                                                                   
  The buffered query path was intersecting per-band result sets directly. That is stricter than normal LSH query behavior, which unions        
  candidates across bands for a query and only then intersects across multiple buffered queries.                                               
                                                                                                                                               
  This caused valid candidates to be dropped when using buffered queries.                                                                      
                                                                                                                                               
  The Cassandra backend also exposed a related issue in buffered selects: repeated buffered lookups with the same hash key could be collapsed  
  instead of preserving one result list per buffered query. That breaks per-query aggregation logic.                                           
                                                                                                                                               
  ## Fix                                                                                                                                       
  - union bucket hits across bands for each buffered query                                                                                     
  - intersect only the per-query candidate sets across the buffer                                                                              
  - preserve existing `prepickle` behavior                                                                                                     
  - make Cassandra buffered selects preserve query order and count, including duplicate hash-key lookups                                       
  - replace a broken LSH Forest documentation link with a stable reference                                                                     
                                                                                                                                               
  ## Test                                                                                                                                      
  - add a regression test showing `collect_query_buffer()` returns the same candidates as `query()` for a case where the old implementation    
  dropped a valid match                                                                                                                        
                                                                                                                                               
  ## Verification                                                                                                                              
  - confirmed with a direct local repro that buffered and non-buffered query paths now both return `[0, 1]`                                    
  - ran `uvx ruff check .`                                                                                                                     
  - ran the README test command `uv run pytest` in Linux/WSL: `158 passed, 76 skipped`                                                         
  - verified the docs link check fix locally with `lychee`