### PR TITLE
Fix WeightedMinHash input mutation

### DIFF
--- a/datasketch/weighted_minhash.py
+++ b/datasketch/weighted_minhash.py
@@ -141,6 +141,8 @@ class WeightedMinHashGenerator:
             v = np.array(v, dtype=np.float32)
         elif v.dtype != np.float32:
             v = v.astype(np.float32)
+        else:
+            v = v.copy()
         v: np.ndarray = v
         hashvalues = np.zeros((self.sample_size, 2), dtype=int)
         vzeros = v == 0

--- a/test/test_weighted_minhash.py
+++ b/test/test_weighted_minhash.py
@@ -34,6 +34,13 @@ class TestWeightedMinHashGenerator(unittest.TestCase):
         self.assertEqual(len(m), 4)
         self.assertTrue(m.hashvalues.dtype == int)
 
+    def test_minhash_does_not_mutate_float32_input(self):
+        mg = WeightedMinHashGenerator(3, 4, 1)
+        v = np.array([1, 0, 3], dtype=np.float32)
+        expected = v.copy()
+        mg.minhash(v)
+        np.testing.assert_array_equal(v, expected)
+
     def test_minhash_many_dense_onerow(self):
         mg = WeightedMinHashGenerator(2, 4, 1)
         m_list = mg.minhash_many(np.array([1, 3]).reshape(1, 2))


### PR DESCRIPTION
## Summary

Fixes a mutation bug in `WeightedMinHashGenerator.minhash()` where passing a `np.float32` input array with zero values caused the caller-owned array to be modified in place.

The method replaces zero entries with `NaN` internally before taking logs. For existing `float32` numpy arrays, the code reused the caller’s array directly, so zeros in the original input became `NaN` after calling `minhash()`.

## Fix

- Copy `float32` numpy inputs before applying the internal zero-to-`NaN` transformation.
- Add a regression test to confirm `minhash()` does not mutate `float32` input arrays.

## Tests

python -m pytest -o addopts= test/test_weighted_minhash.py
python -m pytest -o addopts= test/test_minhash.py test/test_hyperloglog.py test/test_lshforest.py