### PR TITLE
Fix b-bit MinHash estimator correction

### DIFF
--- a/datasketch/b_bit_minhash.py
+++ b/datasketch/b_bit_minhash.py
@@ -182,7 +182,7 @@ class bBitMinHash:
         if r == 0.0:
             # Find the limit of A(r, b) as r -> 0.
             return 1.0 / (1 << b)
-        return r * (1 - r) ** (2**b - 1) / (1 - (1 - r) ** (2 * b))
+        return r * (1 - r) ** (2**b - 1) / (1 - (1 - r) ** (2**b))
 
     def _calc_c(self, a1, a2, r1, r2):
         """Compute the functions C1 and C2."""

--- a/test/test_minhash.py
+++ b/test/test_minhash.py
@@ -194,6 +194,12 @@ class TestbBitMinHash(unittest.TestCase):
         bm1 = bBitMinHash(m1)
         self.assertTrue(bm1.jaccard(bm2) < 1.0)
 
+    def test_calc_a_uses_exponential_bucket_count(self):
+        r = 0.2
+        b = 3
+        expected = r * (1 - r) ** (2**b - 1) / (1 - (1 - r) ** (2**b))
+        self.assertAlmostEqual(bBitMinHash(self.m, b, r)._calc_a(r, b), expected)
+
     def test_bytesize(self):
         s = bBitMinHash(self.m).bytesize()
         self.assertGreaterEqual(s, 8 * 2 + 4 + 1 + self.m.hashvalues.size / 64)


### PR DESCRIPTION
## What
Correct the b-bit MinHash A(r, b) denominator to use the required 2^b exponent and add a focused regression test.

## Why
The previous 2*b exponent produced a biased correction whenever b was greater than two and r was nonzero.

## Impact
Jaccard estimates using a nonzero universe ratio now follow the published estimator. The r=0 behavior is unchanged.

## Root cause
The exponentiation term was transcribed as multiplication.

## Checks
- uv run pytest -q test/test_minhash.py (18 passed)
- uv run ruff check datasketch/b_bit_minhash.py test/test_minhash.py
- git diff --check