### PR TITLE
Enforce MinHash construction compatibility

### DIFF
--- a/datasketch/aio/lsh.py
+++ b/datasketch/aio/lsh.py
@@ -14,7 +14,7 @@ from datasketch.aio.storage import (
     async_unordered_storage,
 )
 from datasketch.lsh import _optimal_param
-from datasketch.minhash import _check_scheme_consistency
+from datasketch.minhash import _check_minhash_compatibility
 from datasketch.storage import _random_name, unordered_storage
 
 
@@ -89,10 +89,10 @@ class AsyncMinHashLSH:
         self.hashranges = [(i * self.r, (i + 1) * self.r) for i in range(self.b)]
         self.hashtables = None
         self.keys = None
-        # The permutation scheme of the indexed MinHash, learned from the
-        # first insert. Note that an index attached to pre-existing external
-        # storage re-learns the scheme on its first insert.
+        # MinHash construction metadata learned from the first insert. An
+        # index attached to pre-existing external storage re-learns it.
         self._minhash_scheme: Optional[str] = None
+        self._minhash_config = None
 
         self._lock = asyncio.Lock()
         self._initialized = False
@@ -253,7 +253,10 @@ class AsyncMinHashLSH:
     async def _insert(self, key, minhash, check_duplication=True, buffer=False):
         if len(minhash) != self.h:
             raise ValueError("Expecting minhash with length %d, got %d" % (self.h, len(minhash)))
-        self._minhash_scheme = _check_scheme_consistency(getattr(self, "_minhash_scheme", None), minhash)
+        known = getattr(self, "_minhash_config", getattr(self, "_minhash_scheme", None))
+        self._minhash_config = _check_minhash_compatibility(known, minhash)
+        if self._minhash_config is not None:
+            self._minhash_scheme = self._minhash_config[0]
         if self._require_bytes_keys and not isinstance(key, bytes):
             raise TypeError(
                 f"prepickle=False requires bytes keys for non-dict storage, got {type(key).__name__}. "
@@ -278,7 +281,8 @@ class AsyncMinHashLSH:
         """See :class:`datasketch.MinHashLSH`."""
         if len(minhash) != self.h:
             raise ValueError("Expecting minhash with length %d, got %d" % (self.h, len(minhash)))
-        _check_scheme_consistency(getattr(self, "_minhash_scheme", None), minhash)
+        known = getattr(self, "_minhash_config", getattr(self, "_minhash_scheme", None))
+        _check_minhash_compatibility(known, minhash)
 
         fs = (
             hashtable.get(self._H(minhash.hashvalues[start:end]))
@@ -329,7 +333,8 @@ class AsyncMinHashLSH:
     async def _query_b(self, minhash, b):
         if len(minhash) != self.h:
             raise ValueError("Expecting minhash with length %d, got %d" % (self.h, len(minhash)))
-        _check_scheme_consistency(getattr(self, "_minhash_scheme", None), minhash)
+        known = getattr(self, "_minhash_config", getattr(self, "_minhash_scheme", None))
+        _check_minhash_compatibility(known, minhash)
         if b > len(self.hashtables):
             raise ValueError("b must be less or equal to the number of hash tables")
         fs = []

--- a/datasketch/lsh.py
+++ b/datasketch/lsh.py
@@ -7,7 +7,7 @@ from typing import Callable, List, Optional, Union
 
 from scipy.integrate import quad as integrate
 
-from datasketch.minhash import MinHash, _check_scheme_consistency
+from datasketch.minhash import MinHash, _check_minhash_compatibility
 from datasketch.storage import (
     OrderedStorage,
     UnorderedStorage,
@@ -198,10 +198,10 @@ class MinHashLSH:
         ]
         self.hashranges = [(i * self.r, (i + 1) * self.r) for i in range(self.b)]
         self.keys: OrderedStorage = ordered_storage(storage_config, name=b"".join([basename, b"_keys"]))
-        # The permutation scheme of the indexed MinHash, learned from the
-        # first insert. Note that an index attached to pre-existing external
-        # storage (e.g. Redis) re-learns the scheme on its first insert.
+        # MinHash construction metadata learned from the first insert. An
+        # index attached to pre-existing external storage re-learns it.
         self._minhash_scheme: Optional[str] = None
+        self._minhash_config = None
 
     @property
     def buffer_size(self) -> int:
@@ -338,7 +338,10 @@ class MinHashLSH:
     ):
         if len(minhash) != self.h:
             raise ValueError("Expecting minhash with length %d, got %d" % (self.h, len(minhash)))
-        self._minhash_scheme = _check_scheme_consistency(getattr(self, "_minhash_scheme", None), minhash)
+        known = getattr(self, "_minhash_config", getattr(self, "_minhash_scheme", None))
+        self._minhash_config = _check_minhash_compatibility(known, minhash)
+        if self._minhash_config is not None:
+            self._minhash_scheme = self._minhash_config[0]
         if self._require_bytes_keys and not isinstance(key, bytes):
             raise TypeError(
                 f"prepickle=False requires bytes keys for non-dict storage, got {type(key).__name__}. "
@@ -370,16 +373,14 @@ class MinHashLSH:
 
     def _merge(self, other: MinHashLSH, check_overlap: bool = False, buffer: bool = False) -> None:
         if self.__equivalent(other):
-            known, other_known = getattr(self, "_minhash_scheme", None), getattr(other, "_minhash_scheme", None)
-            if known is not None and other_known is not None and known != other_known:
-                raise ValueError(
-                    "Cannot merge MinHashLSH indexed with MinHash scheme %r into one indexed with scheme %r"
-                    % (other_known, known)
-                )
+            known = getattr(self, "_minhash_config", getattr(self, "_minhash_scheme", None))
+            other_known = getattr(other, "_minhash_config", getattr(other, "_minhash_scheme", None))
+            merged_config = _check_minhash_compatibility(known, other_known)
             if check_overlap and set(self.keys).intersection(set(other.keys)):
                 raise ValueError("The keys are overlapping, duplicate key exists.")
-            if known is None:
-                self._minhash_scheme = other_known
+            self._minhash_config = merged_config
+            if merged_config is not None:
+                self._minhash_scheme = merged_config[0]
             for key in other.keys:
                 Hs = other.keys.get(key)
                 self.keys.insert(key, *Hs, buffer=buffer)
@@ -445,7 +446,8 @@ class MinHashLSH:
         """
         if len(minhash) != self.h:
             raise ValueError("Expecting minhash with length %d, got %d" % (self.h, len(minhash)))
-        _check_scheme_consistency(getattr(self, "_minhash_scheme", None), minhash)
+        known = getattr(self, "_minhash_config", getattr(self, "_minhash_scheme", None))
+        _check_minhash_compatibility(known, minhash)
         candidates = set()
         for (start, end), hashtable in zip(self.hashranges, self.hashtables):
             H = self._H(minhash.hashvalues[start:end])
@@ -472,7 +474,8 @@ class MinHashLSH:
         """
         if len(minhash) != self.h:
             raise ValueError("Expecting minhash with length %d, got %d" % (self.h, len(minhash)))
-        _check_scheme_consistency(getattr(self, "_minhash_scheme", None), minhash)
+        known = getattr(self, "_minhash_config", getattr(self, "_minhash_scheme", None))
+        _check_minhash_compatibility(known, minhash)
         for (start, end), hashtable in zip(self.hashranges, self.hashtables):
             H = self._H(minhash.hashvalues[start:end])
             hashtable.add_to_select_buffer([H])
@@ -570,7 +573,8 @@ class MinHashLSH:
     def _query_b(self, minhash, b):
         if len(minhash) != self.h:
             raise ValueError("Expecting minhash with length %d, got %d" % (self.h, len(minhash)))
-        _check_scheme_consistency(getattr(self, "_minhash_scheme", None), minhash)
+        known = getattr(self, "_minhash_config", getattr(self, "_minhash_scheme", None))
+        _check_minhash_compatibility(known, minhash)
         if b > len(self.hashtables):
             raise ValueError("b must be less or equal to the number of hash tables")
         candidates = set()

--- a/datasketch/lsh_bloom.py
+++ b/datasketch/lsh_bloom.py
@@ -8,7 +8,7 @@ from typing import Optional
 import numpy as np
 from scipy.integrate import quad as integrate
 
-from datasketch.minhash import MinHash, _check_scheme_consistency
+from datasketch.minhash import MinHash, _check_minhash_compatibility
 
 try:
     import pybloomfilter
@@ -298,10 +298,10 @@ class MinHashLSHBloom:
             for i in range(self.b)
         ]
         self.hashranges = [(i * self.r, (i + 1) * self.r) for i in range(self.b)]
-        # The permutation scheme of the indexed MinHash, learned from the
-        # first insert. Note that an index restored from Bloom filter files
-        # re-learns the scheme on its first insert.
+        # MinHash construction metadata learned from the first insert. An
+        # index restored from Bloom filter files re-learns it.
         self._minhash_scheme: Optional[str] = None
+        self._minhash_config = None
 
     def insert(self, minhash: MinHash):
         """Insert the MinHash or Weighted MinHash
@@ -316,7 +316,10 @@ class MinHashLSHBloom:
     def _insert(self, minhash: MinHash):
         if len(minhash) != self.h:
             raise ValueError("Expecting minhash with length %d, got %d" % (self.h, len(minhash)))
-        self._minhash_scheme = _check_scheme_consistency(getattr(self, "_minhash_scheme", None), minhash)
+        known = getattr(self, "_minhash_config", getattr(self, "_minhash_scheme", None))
+        self._minhash_config = _check_minhash_compatibility(known, minhash)
+        if self._minhash_config is not None:
+            self._minhash_scheme = self._minhash_config[0]
 
         Hs = [minhash.hashvalues[start:end] for start, end in self.hashranges]
 
@@ -371,7 +374,8 @@ class MinHashLSHBloom:
         """
         if len(minhash) != self.h:
             raise ValueError("Expecting minhash with length %d, got %d" % (self.h, len(minhash)))
-        _check_scheme_consistency(getattr(self, "_minhash_scheme", None), minhash)
+        known = getattr(self, "_minhash_config", getattr(self, "_minhash_scheme", None))
+        _check_minhash_compatibility(known, minhash)
 
         # if we match in any band, this is a candidate pair
         for (start, end), hashtable in zip(self.hashranges, self.hashtables):

--- a/datasketch/lshensemble.py
+++ b/datasketch/lshensemble.py
@@ -245,8 +245,8 @@ class MinHashLSHEnsemble:
             if u is None:
                 continue
             b, r = self._get_optimal_param(u, size)
-            # The permutation-scheme guard lives in the inner MinHashLSH
-            # (_query_b calls _check_scheme_consistency), so it is checked
+            # The MinHash compatibility guard lives in the inner MinHashLSH,
+            # so it is checked
             # lazily as this generator is iterated and only for partitions
             # that have had an insert. A query reaching only empty partitions
             # returns nothing regardless, so it cannot yield wrong results.

--- a/datasketch/lshforest.py
+++ b/datasketch/lshforest.py
@@ -3,7 +3,7 @@ from collections.abc import Hashable
 
 import numpy as np
 
-from datasketch.minhash import MinHash, _check_scheme_consistency
+from datasketch.minhash import MinHash, _check_minhash_compatibility
 
 
 class MinHashLSHForest:
@@ -42,8 +42,9 @@ class MinHashLSHForest:
         self.keys = dict()
         # This is the sorted array implementation for the prefix trees
         self.sorted_hashtables = [[] for _ in range(self.l)]
-        # The permutation scheme of the indexed MinHash, learned on first add.
+        # MinHash construction metadata learned on first add.
         self._minhash_scheme = None
+        self._minhash_config = None
 
     def add(self, key: Hashable, minhash: MinHash) -> None:
         """Add a unique key, together
@@ -60,8 +61,10 @@ class MinHashLSHForest:
         """
         if len(minhash) < self.k * self.l:
             raise ValueError("The num_perm of MinHash out of range")
-        self._minhash_scheme = _check_scheme_consistency(
-            getattr(self, "_minhash_scheme", None), minhash)
+        known = getattr(self, "_minhash_config", getattr(self, "_minhash_scheme", None))
+        self._minhash_config = _check_minhash_compatibility(known, minhash)
+        if self._minhash_config is not None:
+            self._minhash_scheme = self._minhash_config[0]
         if key in self.keys:
             raise ValueError("The given key has already been added")
         self.keys[key] = [self._H(minhash.hashvalues[start:end])
@@ -121,7 +124,8 @@ class MinHashLSHForest:
             raise ValueError("k must be positive")
         if len(minhash) < self.k * self.l:
             raise ValueError("The num_perm of MinHash out of range")
-        _check_scheme_consistency(getattr(self, "_minhash_scheme", None), minhash)
+        known = getattr(self, "_minhash_config", getattr(self, "_minhash_scheme", None))
+        _check_minhash_compatibility(known, minhash)
         results = set()
         r = self.k
         while r > 0:

--- a/datasketch/minhash.py
+++ b/datasketch/minhash.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import copy
+import hashlib
+import marshal
 import warnings
 from collections.abc import Generator, Iterable
 from typing import TYPE_CHECKING, Callable, Optional, Union
@@ -108,26 +110,93 @@ def _fmix(hv, width: int):
     return hv ^ (hv >> s3)
 
 
-def _check_scheme_consistency(known: Optional[str], minhash) -> Optional[str]:
-    """Check the permutation scheme of a MinHash given to an LSH index
-    against the scheme of the MinHash previously given to it, and return
-    the scheme the index should remember.
+def _permutations_fingerprint(permutations) -> str:
+    """Return a compact fingerprint of a MinHash permutation matrix."""
+    values = np.ascontiguousarray(permutations)
+    digest = hashlib.sha256()
+    digest.update(values.dtype.str.encode("ascii"))
+    digest.update(repr(values.shape).encode("ascii"))
+    digest.update(values.tobytes())
+    return digest.hexdigest()
 
-    Hash values carry no trace of the scheme that produced them, so mixing
-    schemes in one index silently returns wrong results instead of failing;
-    this check makes it fail. Sketch types without a scheme attribute
-    (WeightedMinHash) are exempt.
+
+def _hashfunc_fingerprint(hashfunc: Callable) -> str:
+    """Return a stable-enough fingerprint for a hash callable.
+
+    Python functions include their bytecode, defaults, and closure values;
+    callable objects additionally include their instance state. This is a
+    compatibility guard, not a serialization format or security boundary.
     """
+    digest = hashlib.sha256()
+    callable_type = type(hashfunc)
+    parts = (
+        getattr(hashfunc, "__module__", callable_type.__module__),
+        getattr(hashfunc, "__qualname__", callable_type.__qualname__),
+    )
+    digest.update(repr(parts).encode("utf-8"))
+    code = getattr(hashfunc, "__code__", None)
+    if code is None and callable(hashfunc):
+        code = getattr(hashfunc.__call__, "__code__", None)
+    if code is not None:
+        digest.update(marshal.dumps(code))
+    digest.update(repr(getattr(hashfunc, "__defaults__", None)).encode("utf-8"))
+    digest.update(repr(getattr(hashfunc, "__kwdefaults__", None)).encode("utf-8"))
+    closure = getattr(hashfunc, "__closure__", None)
+    if closure is not None:
+        digest.update(repr(tuple(cell.cell_contents for cell in closure)).encode("utf-8"))
+    digest.update(repr(getattr(hashfunc, "__dict__", None)).encode("utf-8"))
+    return digest.hexdigest()
+
+
+def _minhash_compatibility(minhash):
+    """Return the comparable MinHash construction metadata, when available."""
     scheme = getattr(minhash, "scheme", None)
     if scheme is None:
+        # WeightedMinHash has no permutation scheme and remains exempt.
+        return None
+    permutations = getattr(minhash, "permutations", None)
+    hashfunc = getattr(minhash, "hashfunc", None)
+    return (
+        scheme,
+        _permutations_fingerprint(permutations) if permutations is not None else None,
+        _hashfunc_fingerprint(hashfunc) if hashfunc is not None else None,
+    )
+
+
+def _check_minhash_compatibility(known, minhash):
+    """Check MinHash construction metadata against metadata already known.
+
+    LSH indexes use this to prevent mixing sketches made with different
+    permutation matrices or hash functions. A legacy string value is accepted
+    for indexes pickled before the richer compatibility metadata was added.
+
+    Hash values carry no trace of the scheme that produced them, so mixing
+    incompatible sketches silently returns wrong results instead of failing.
+    Sketch types without a scheme attribute (WeightedMinHash) are exempt.
+    """
+    if isinstance(known, str):
+        known = (known, None, None)
+    candidate = minhash if isinstance(minhash, tuple) and len(minhash) == 3 else _minhash_compatibility(minhash)
+    if candidate is None:
         return known
     if known is None:
-        return scheme
-    if scheme != known:
+        return candidate
+    known_scheme, known_permutations, known_hashfunc = known
+    scheme, permutations, hashfunc = candidate
+    if scheme != known_scheme:
         raise ValueError(
-            "MinHash scheme %r does not match scheme %r of the MinHash previously given to this index" % (scheme, known)
+            "MinHash scheme %r does not match scheme %r of the MinHash previously given to this index"
+            % (scheme, known_scheme)
         )
-    return known
+    if known_permutations is not None and permutations is not None and permutations != known_permutations:
+        raise ValueError("MinHash permutations do not match those of the MinHash previously given to this index")
+    if known_hashfunc is not None and hashfunc is not None and hashfunc != known_hashfunc:
+        raise ValueError("MinHash hash function does not match that of the MinHash previously given to this index")
+    return (
+        known_scheme,
+        known_permutations if known_permutations is not None else permutations,
+        known_hashfunc if known_hashfunc is not None else hashfunc,
+    )
 
 
 _GPU_OK_CACHE: Optional[bool] = None
@@ -550,7 +619,8 @@ class MinHash:
         Raises:
             ValueError: If the two MinHashes have different numbers of
                 permutation functions, different seeds, or different
-                permutation schemes.
+                permutation schemes, permutation parameters, or hash
+                functions.
 
         """
         if getattr(other, "scheme", None) != self.scheme:
@@ -565,6 +635,7 @@ class MinHash:
             raise ValueError(
                 "Cannot compute Jaccard given MinHash with different numbers of permutation functions"
             )
+        _check_minhash_compatibility(_minhash_compatibility(self), other)
         return float(np.count_nonzero(self.hashvalues == other.hashvalues)) / float(len(self))
 
     def count(self) -> float:
@@ -588,7 +659,8 @@ class MinHash:
         Raises:
             ValueError: If the two MinHashes have different numbers of
                 permutation functions, different seeds, or different
-                permutation schemes.
+                permutation schemes, permutation parameters, or hash
+                functions.
 
         """
         if getattr(other, "scheme", None) != self.scheme:
@@ -603,6 +675,7 @@ class MinHash:
             raise ValueError(
                 "Cannot merge MinHash with different numbers of permutation functions"
             )
+        _check_minhash_compatibility(_minhash_compatibility(self), other)
         self.hashvalues = np.minimum(other.hashvalues, self.hashvalues)
 
     def digest(self) -> np.ndarray:
@@ -649,13 +722,14 @@ class MinHash:
 
     def __eq__(self, other: MinHash) -> bool:
         """Returns:
-        bool: If their schemes, seeds and hash values are all equal then two are equivalent.
+        bool: If their construction metadata and hash values are all equal then two are equivalent.
 
         """
         return (
             type(self) is type(other)
             and self.scheme == other.scheme
             and self.seed == other.seed
+            and _minhash_compatibility(self) == _minhash_compatibility(other)
             and np.array_equal(self.hashvalues, other.hashvalues)
         )
 
@@ -674,7 +748,8 @@ class MinHash:
             ValueError: If the number of MinHash objects passed as arguments is less than 2,
                 or if the MinHash objects passed as arguments have different seeds,
                 different numbers of permutation functions, or different
-                permutation schemes.
+                permutation schemes, permutation parameters, or hash
+                functions.
 
         Example:
 
@@ -702,6 +777,9 @@ class MinHash:
             raise ValueError(
                 "The unioning MinHash must have the same seed, number of permutation functions and scheme"
             )
+        compatibility = _minhash_compatibility(mhs[0])
+        for minhash in mhs[1:]:
+            _check_minhash_compatibility(compatibility, minhash)
         hashvalues = np.minimum.reduce([m.hashvalues for m in mhs])
         permutations = mhs[0].permutations
         return cls(

--- a/test/test_minhash.py
+++ b/test/test_minhash.py
@@ -8,6 +8,10 @@ from datasketch.b_bit_minhash import bBitMinHash
 from test.utils import fake_hash_func
 
 
+def alternate_fake_hash_func(data):
+    return data + 1
+
+
 class TestMinHash(unittest.TestCase):
     def test_init(self):
         m1 = minhash.MinHash(4, 1, hashfunc=fake_hash_func)
@@ -65,6 +69,34 @@ class TestMinHash(unittest.TestCase):
         self.assertIs(u.hashfunc, fake_hash_func)
         self.assertEqual(u._gpu_mode, "detect")
         u.update(13)
+
+    def test_operations_reject_different_hash_functions(self):
+        m1 = minhash.MinHash(4, 1, hashfunc=fake_hash_func)
+        m2 = minhash.MinHash(4, 1, hashfunc=alternate_fake_hash_func)
+        with self.assertRaisesRegex(ValueError, "hash function"):
+            m1.jaccard(m2)
+        with self.assertRaisesRegex(ValueError, "hash function"):
+            m1.merge(m2)
+        with self.assertRaisesRegex(ValueError, "hash function"):
+            minhash.MinHash.union(m1, m2)
+
+    def test_operations_reject_different_explicit_permutations(self):
+        m1 = minhash.MinHash(4, 1, hashfunc=fake_hash_func)
+        permutations = m1.permutations.copy()
+        permutations[1, 0] += 1
+        m2 = minhash.MinHash(
+            4,
+            1,
+            hashfunc=fake_hash_func,
+            permutations=permutations,
+            scheme=m1.scheme,
+        )
+        with self.assertRaisesRegex(ValueError, "permutations"):
+            m1.jaccard(m2)
+        with self.assertRaisesRegex(ValueError, "permutations"):
+            m1.merge(m2)
+        with self.assertRaisesRegex(ValueError, "permutations"):
+            minhash.MinHash.union(m1, m2)
 
     def test_pickle(self):
         m = minhash.MinHash(4, 1, hashfunc=fake_hash_func)

--- a/test/test_minhash_schemes.py
+++ b/test/test_minhash_schemes.py
@@ -29,6 +29,10 @@ from test.utils import fake_hash_func
 AFFINE_SCHEMES = ("affine32", "affine64")
 ALL_SCHEMES = ("affine32", "affine64", "legacy")
 
+
+def alternate_fake_hash_func(data):
+    return data + 1
+
 # --------------------------------------------------------------------------
 # Frozen format vectors. These freeze the affine schemes' permutation
 # generation and hash computation: any change to these values is a breaking
@@ -352,6 +356,46 @@ class TestLSHSchemeGuards(unittest.TestCase):
         with self.assertRaises(ValueError):
             restored.query(self._mh("legacy"))
         self.assertIn("k", restored.query(self._mh("affine32")))
+
+    def test_lsh_rejects_different_hash_function(self):
+        first = MinHash(128, hashfunc=fake_hash_func)
+        incompatible = MinHash(128, hashfunc=alternate_fake_hash_func)
+        lsh = MinHashLSH(threshold=0.5, num_perm=128)
+        lsh.insert("first", first)
+        with self.assertRaisesRegex(ValueError, "hash function"):
+            lsh.insert("second", incompatible)
+        with self.assertRaisesRegex(ValueError, "hash function"):
+            lsh.query(incompatible)
+
+        other = MinHashLSH(threshold=0.5, num_perm=128)
+        other.insert("second", incompatible)
+        with self.assertRaisesRegex(ValueError, "hash function"):
+            lsh.merge(other)
+
+    def test_lsh_and_forest_reject_different_permutations(self):
+        first = MinHash(128, hashfunc=fake_hash_func)
+        permutations = first.permutations.copy()
+        permutations[1, 0] += 1
+        incompatible = MinHash(
+            128,
+            seed=first.seed,
+            hashfunc=fake_hash_func,
+            permutations=permutations,
+            scheme=first.scheme,
+        )
+
+        lsh = MinHashLSH(threshold=0.5, num_perm=128)
+        lsh.insert("first", first)
+        with self.assertRaisesRegex(ValueError, "permutations"):
+            lsh.query(incompatible)
+
+        forest = MinHashLSHForest(num_perm=128)
+        forest.add("first", first)
+        with self.assertRaisesRegex(ValueError, "permutations"):
+            forest.add("second", incompatible)
+        forest.index()
+        with self.assertRaisesRegex(ValueError, "permutations"):
+            forest.query(incompatible, 1)
 
     def test_lshforest_mixed_scheme_raises(self):
         forest = MinHashLSHForest(num_perm=128)

--- a/test/test_minhash_schemes.py
+++ b/test/test_minhash_schemes.py
@@ -10,6 +10,7 @@ import base64
 import pickle
 import struct
 import unittest
+from unittest.mock import AsyncMock, Mock
 
 import numpy as np
 
@@ -21,9 +22,10 @@ from datasketch import (
     MinHashLSHForest,
     WeightedMinHashGenerator,
 )
+from datasketch.aio import AsyncMinHashLSH
 from datasketch.b_bit_minhash import bBitMinHash
 from datasketch.hashfunc import sha1_hash32, sha1_hash64
-from datasketch.minhash import _fmix
+from datasketch.minhash import _check_minhash_compatibility, _fmix, _hashfunc_fingerprint
 from test.utils import fake_hash_func
 
 AFFINE_SCHEMES = ("affine32", "affine64")
@@ -32,6 +34,21 @@ ALL_SCHEMES = ("affine32", "affine64", "legacy")
 
 def alternate_fake_hash_func(data):
     return data + 1
+
+
+class StatefulHash:
+    def __init__(self, offset):
+        self.offset = offset
+
+    def __call__(self, data):
+        return fake_hash_func(data) + self.offset
+
+
+def make_closure_hash(offset):
+    def closure_hash(data):
+        return fake_hash_func(data) + offset
+
+    return closure_hash
 
 # --------------------------------------------------------------------------
 # Frozen format vectors. These freeze the affine schemes' permutation
@@ -372,6 +389,16 @@ class TestLSHSchemeGuards(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "hash function"):
             lsh.merge(other)
 
+    def test_hash_function_fingerprint_covers_callable_state_and_closures(self):
+        self.assertNotEqual(_hashfunc_fingerprint(StatefulHash(1)), _hashfunc_fingerprint(StatefulHash(2)))
+        self.assertNotEqual(_hashfunc_fingerprint(make_closure_hash(1)), _hashfunc_fingerprint(make_closure_hash(2)))
+
+    def test_legacy_scheme_metadata_is_upgraded(self):
+        compatibility = _check_minhash_compatibility("affine32", MinHash(16, scheme="affine32"))
+        self.assertEqual(compatibility[0], "affine32")
+        self.assertIsNotNone(compatibility[1])
+        self.assertIsNotNone(compatibility[2])
+
     def test_lsh_and_forest_reject_different_permutations(self):
         first = MinHash(128, hashfunc=fake_hash_func)
         permutations = first.permutations.copy()
@@ -421,6 +448,36 @@ class TestLSHSchemeGuards(unittest.TestCase):
         lsh = MinHashLSH(threshold=0.5, num_perm=128)
         lsh.insert("w1", gen.minhash(v))
         self.assertIn("w1", lsh.query(gen.minhash(v)))
+
+
+class TestAsyncLSHCompatibility(unittest.IsolatedAsyncioTestCase):
+    async def test_async_lsh_rejects_incompatible_hash_functions(self):
+        first = MinHash(16, hashfunc=fake_hash_func)
+        incompatible = MinHash(16, hashfunc=alternate_fake_hash_func)
+        lsh = AsyncMinHashLSH(
+            num_perm=16,
+            params=(4, 4),
+            storage_config={"type": "aiomongo"},
+            prepickle=False,
+        )
+        lsh.keys = Mock(
+            has_key=AsyncMock(return_value=False),
+            insert=AsyncMock(),
+        )
+        lsh.hashtables = [
+            Mock(
+                insert=AsyncMock(),
+                get=AsyncMock(return_value=[b"first"]),
+                has_key=AsyncMock(return_value=True),
+            )
+            for _ in range(lsh.b)
+        ]
+
+        await lsh._insert(b"first", first)
+        with self.assertRaisesRegex(ValueError, "hash function"):
+            await lsh.query(incompatible)
+        with self.assertRaisesRegex(ValueError, "hash function"):
+            await lsh._query_b(incompatible, lsh.b)
 
 
 class TestFrozenFormat(unittest.TestCase):


### PR DESCRIPTION
## Summary

MinHash sketches can share a seed, length, and scheme while using different permutation matrices or hash functions. Track construction metadata and reject incompatible comparisons, merges, and LSH operations instead of returning invalid similarity results.

The callable fingerprint includes partial arguments, bound-instance state, defaults, closures, and callable state. Source filenames and line locations do not affect compatibility, so persisted indexes can be used after relocating an installation. WeightedMinHash remains exempt, and legacy scheme-only metadata remains readable.

## Validation

- Targeted MinHash/LSH tests and the persisted-index subprocess regression passed.
- Ruff and Pyright passed.
- All 13 upstream GitHub checks passed for 0c98104, including Python 3.9–3.13 and backend integration jobs.
